### PR TITLE
배포 워크플로 수정: EC2 경로 및 트리거 보강

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -7,6 +7,7 @@ on:
       - 'app/**'
       - 'pipeline/**'
       - 'config/**'
+      - 'data/dummy/**'
       - 'requirements.txt'
       - 'scripts/**'
 
@@ -21,7 +22,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            cd ~/tell-me-lion
+            cd ~/wonder-girls
             git pull origin main
             source venv/bin/activate
             pip install -r requirements.txt --quiet


### PR DESCRIPTION
## Summary
- EC2 서버 디렉터리 경로 `~/tell-me-lion` → `~/wonder-girls` 수정
- `data/dummy/**` 변경 시에도 자동 배포 트리거 추가

## Test plan
- [ ] 다음 백엔드 변경 시 GitHub Actions 배포 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)