### PR TITLE
강의 페이지 분할 패널 레이아웃 및 선택 분석 UI 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,26 +22,77 @@
 
 ---
 
+## 디렉터리 구조
+
+```
+tell-me-lion/
+├── frontend/          # React + TypeScript + Vite (주노 담당)
+│   └── src/
+│       ├── pages/     # 라우트별 페이지 컴포넌트
+│       ├── components/# 공용 컴포넌트
+│       ├── services/  # API 호출 (api.ts)
+│       ├── types/     # TypeScript 타입 (models.ts)
+│       ├── hooks/     # 커스텀 훅
+│       └── index.css  # 전역 스타일 (CSS 변수 포함)
+├── app/               # FastAPI 백엔드
+│   ├── api/           # 라우터
+│   ├── schemas/       # Pydantic 모델
+│   └── main.py        # 엔트리포인트
+├── pipeline/          # 전처리 파이프라인 (시훈 담당)
+├── data/              # 더미 데이터 (백엔드 연동 전 시연용)
+├── docs/tasks/        # 태스크 명세 파일
+├── DESIGN.md          # 색상·타이포·컴포넌트 스펙
+└── PROJECT_GOALS.md   # 전체 평가 기준·제출물 목록
+```
+
+---
+
+## 커맨드
+
+```bash
+# 프론트엔드 (frontend/ 디렉터리에서)
+npm run dev        # 개발 서버 (localhost:5173)
+npm run build      # 프로덕션 빌드 (tsc -b && vite build)
+npm run lint       # ESLint
+npm run test       # Vitest 단위 테스트
+npm run preview    # 빌드 결과 미리보기
+
+# 백엔드 (루트에서)
+uvicorn app.main:app --reload   # 개발 서버 (localhost:8000)
+```
+
+---
+
 ## 실행 원칙
 
-- 코드 작성 요청 → 즉시 파일에 직접 작성 (계획·설명 먼저 금지)
+- **명시적 코드 작성 요청** → 즉시 파일에 직접 작성 (계획·설명 먼저 금지)
+- **변경·기능 제안 시** → 유저에게 먼저 확인 → `docs/tasks/`에 태스크 파일 작성 → 승인 후 구현
 - 작성 후 Read 도구로 반영 확인
 - 하드코딩 금지: 색상(`var(--tml-*)`), 데이터(API 연동), URL(환경변수)
 - 관련 스킬이 있으면 수동 작업 전에 Skill 도구 먼저 호출
+
+### docs/tasks/ 태스크 파일 규칙
+
+- 파일명: `TASK-{번호}-{간단설명}.md` (예: `TASK-001-lectures-page-redesign.md`)
+- 내용: 목적, 변경 파일, 작업 항목 체크리스트
+- 구현 완료 후 체크리스트 업데이트
 
 ---
 
 ## 핵심 코딩 규칙
 
 ### 프론트엔드
-- TypeScript 인터페이스 ↔ 백엔드 Pydantic 모델 일치
-- 색상: `DESIGN.md`의 CSS 변수(`var(--tml-*)`) 사용
+
+- TypeScript 인터페이스 ↔ 백엔드 Pydantic 모델 일치 (`types/models.ts` ↔ `app/schemas/`)
+- 색상: `DESIGN.md`의 CSS 변수(`var(--tml-*)`) 사용, 하드코딩 금지
+- 더미 데이터는 `data/` 디렉터리 참조 (백엔드 연동 전)
 
 ### 라우팅 (`react-router-dom` v7)
 
 | 경로 | 페이지 | 설명 |
 |------|--------|------|
 | `/` | `Dashboard` | 대시보드 |
+| `/lectures` | `LecturesPage` | 강의 목록 + 분석 시작 |
 | `/lecture/:id` | `LectureResult` | 단일 강의 결과 (Mode A) |
 | `/weekly/:week` | `WeeklyResult` | 주차별 학습 가이드 (Mode B) |
 | `/lecture`, `/weekly` | → `/` 리다이렉트 | 하위 호환 |
@@ -51,21 +102,30 @@
 
 ---
 
+## 환경 변수
+
+```bash
+# frontend/.env.local (로컬 개발)
+VITE_API_URL=http://localhost:8000
+
+# Vercel 환경변수 (배포)
+VITE_API_URL=http://15.165.140.229
+```
+
+---
+
 ## 배포 환경
 
-| 레이어 | 플랫폼 | 비고 |
+| 레이어 | 플랫폼 | 주소 |
 |--------|--------|------|
 | 프론트엔드 | Vercel | `wonder-girls.vercel.app` |
 | 백엔드 | AWS EC2 | `15.165.140.229` |
-
-- 프론트 API 요청 URL은 환경변수(`VITE_API_BASE_URL`)로 관리
-- 로컬 개발: `.env.local`, 배포: Vercel 환경변수 설정
 
 ---
 
 ## 참고 파일
 
-- `DESIGN.md` — 색상·타이포·컴포넌트 스펙 (UI 작업 시 읽기)
+- `DESIGN.md` — 색상·타이포·컴포넌트 스펙 (UI 작업 시 반드시 읽기)
 - `PROJECT_GOALS.md` — 전체 평가 기준·제출물 목록
 - `docs/tasks/` — 태스크 명세
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1279,6 +1279,150 @@ body::after {
   line-height: 1.5;
 }
 
+/* === 분할 패널 레이아웃 (TASK-001) === */
+
+.tml-split-layout {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 32px;
+  align-items: start;
+  margin-top: 24px;
+}
+
+@media (max-width: 900px) {
+  .tml-split-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* 오른쪽 패널 */
+.tml-right-panel {
+  position: sticky;
+  top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tml-right-panel__section {
+  background: var(--tml-surface);
+  border: 1px solid var(--tml-border);
+  border-radius: 10px;
+  padding: 14px 16px;
+}
+
+.tml-right-panel__section-title {
+  font-family: var(--font-body);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--tml-ink-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 10px;
+}
+
+.tml-right-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tml-right-panel__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--tml-rule);
+}
+
+.tml-right-panel__item:last-child {
+  border-bottom: none;
+}
+
+.tml-right-panel__item-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--tml-ink-secondary);
+}
+
+.tml-right-panel__remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.6875rem;
+  color: var(--tml-ink-muted);
+  padding: 2px 4px;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+  line-height: 1;
+}
+
+.tml-right-panel__remove:hover {
+  color: var(--tml-wrong);
+  background: rgba(255, 80, 80, 0.08);
+}
+
+.tml-right-panel__empty {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  color: var(--tml-ink-muted);
+  text-align: center;
+  padding: 6px 0 2px;
+  margin: 0;
+}
+
+.tml-right-panel__guide-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--tml-navy-mid);
+  padding: 0;
+  transition: color 0.15s;
+}
+
+.tml-right-panel__guide-btn:hover {
+  color: var(--tml-ink);
+}
+
+/* 강의 카드 선택 인터랙션 */
+.tml-lecture-card--selectable {
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.tml-lecture-card--selectable:hover {
+  transform: translateY(-2px);
+}
+
+.tml-lecture-card--selected {
+  outline: 2px solid var(--tml-orange);
+  outline-offset: -2px;
+}
+
+.tml-lecture-card__checkbox {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, border-color 0.15s;
+  pointer-events: none;
+}
+
+.tml-lecture-card__checkbox--checked {
+  background: var(--tml-orange);
+  border-color: var(--tml-orange);
+}
+
 /* === 처리 상태 인디케이터 (Task 05) === */
 
 @keyframes tml-progress-shimmer {

--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -52,22 +52,47 @@ function WeekFilter({ weeks, activeWeek, onSelect }: WeekFilterProps) {
 
 interface LectureCardProps {
   lecture: Lecture
-  onProcess: (lectureId: string) => void
+  isSelected: boolean
+  onToggleSelect: (lectureId: string) => void
   onViewResults: (lectureId: string) => void
   onProcessComplete: (lectureId: string) => void
   onProcessError: (lectureId: string) => void
+  onRetry: (lectureId: string) => void
 }
 
-function LectureCard({ lecture, onProcess, onViewResults, onProcessComplete, onProcessError }: LectureCardProps) {
+function LectureCard({ lecture, isSelected, onToggleSelect, onViewResults, onProcessComplete, onProcessError, onRetry }: LectureCardProps) {
   const { lecture_id, date, day_of_week, week, course_name, status, result_summary } = lecture
   const gradient = getLectureThumbnailGradient(date, week)
 
+  const handleCardClick = () => {
+    if (status === 'idle') onToggleSelect(lecture_id)
+    else if (status === 'completed') onViewResults(lecture_id)
+  }
+
+  const isClickable = status === 'idle' || status === 'completed'
+
   return (
-    <div className="tml-lecture-card tml-card">
-      <div className="tml-lecture-card__thumb" style={{ background: gradient }}>
+    <div
+      className={[
+        'tml-lecture-card tml-card',
+        isClickable ? 'tml-lecture-card--selectable' : '',
+        isSelected ? 'tml-lecture-card--selected' : '',
+      ].join(' ').trim()}
+      onClick={isClickable ? handleCardClick : undefined}
+    >
+      <div className="tml-lecture-card__thumb" style={{ background: gradient, position: 'relative' }}>
         <span className="tml-lecture-card__date-badge">
           {date.slice(5)} ({day_of_week})
         </span>
+        {status === 'idle' && (
+          <span className={`tml-lecture-card__checkbox${isSelected ? ' tml-lecture-card__checkbox--checked' : ''}`}>
+            {isSelected && (
+              <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+                <path d="M1 4L3.5 6.5L9 1" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </span>
+        )}
       </div>
 
       <div className="tml-lecture-card__body">
@@ -75,18 +100,6 @@ function LectureCard({ lecture, onProcess, onViewResults, onProcessComplete, onP
         <p className="tml-lecture-card__week-label">Week {week}</p>
 
         <hr className="tml-lecture-card__rule" />
-
-        {status === 'idle' && (
-          <div className="tml-lecture-card__footer">
-            <button
-              className="btn-primary"
-              style={{ fontSize: '0.8125rem', padding: '6px 14px', width: '100%' }}
-              onClick={() => onProcess(lecture_id)}
-            >
-              가져오기
-            </button>
-          </div>
-        )}
 
         {status === 'processing' && (
           <div className="tml-lecture-card__footer">
@@ -104,12 +117,7 @@ function LectureCard({ lecture, onProcess, onViewResults, onProcessComplete, onP
               <span>개념 {result_summary.concept_count}개</span>
               <span>퀴즈 {result_summary.quiz_count}개</span>
             </div>
-            <button
-              className="tml-lecture-card__result-btn"
-              onClick={() => onViewResults(lecture_id)}
-            >
-              결과 보기 →
-            </button>
+            <span className="tml-lecture-card__result-btn">결과 보기 →</span>
           </div>
         )}
 
@@ -124,7 +132,7 @@ function LectureCard({ lecture, onProcess, onViewResults, onProcessComplete, onP
                 width: '100%',
                 background: 'var(--tml-wrong)',
               }}
-              onClick={() => onProcess(lecture_id)}
+              onClick={(e) => { e.stopPropagation(); onRetry(lecture_id) }}
             >
               재시도
             </button>
@@ -214,10 +222,12 @@ interface WeekSectionProps {
   weekSummary: WeekSummary
   processingLectures: Set<string>
   processingWeeks: Set<number>
-  onProcess: (lectureId: string) => void
+  selectedIds: Set<string>
+  onToggleSelect: (lectureId: string) => void
   onViewResults: (lectureId: string) => void
   onProcessComplete: (lectureId: string) => void
   onProcessError: (lectureId: string) => void
+  onRetry: (lectureId: string) => void
   onProcessWeek: (week: number) => void
   onViewWeekResults: (week: number) => void
   onWeekProcessComplete: (week: number) => void
@@ -228,10 +238,12 @@ function WeekSection({
   weekSummary,
   processingLectures,
   processingWeeks,
-  onProcess,
+  selectedIds,
+  onToggleSelect,
   onViewResults,
   onProcessComplete,
   onProcessError,
+  onRetry,
   onProcessWeek,
   onViewWeekResults,
   onWeekProcessComplete,
@@ -239,7 +251,6 @@ function WeekSection({
 }: WeekSectionProps) {
   const { week, lecture_count, completed_count, date_range, lectures } = weekSummary
 
-  // WeekSummary status 버그 보정: 실제 processing 아닌데 processing으로 오는 경우 idle 처리
   const effectiveWeekStatus: ProcessingStatus = processingWeeks.has(week)
     ? 'processing'
     : weekSummary.status === 'processing' && !processingWeeks.has(week)
@@ -259,19 +270,21 @@ function WeekSection({
       </div>
 
       <div className="tml-lecture-grid">
-        {lectures.map((lecture) => (
-          <LectureCard
-            key={lecture.lecture_id}
-            lecture={{
-              ...lecture,
-              status: processingLectures.has(lecture.lecture_id) ? 'processing' : lecture.status,
-            }}
-            onProcess={onProcess}
-            onViewResults={onViewResults}
-            onProcessComplete={onProcessComplete}
-            onProcessError={onProcessError}
-          />
-        ))}
+        {lectures.map((lecture) => {
+          const effectiveStatus: ProcessingStatus = processingLectures.has(lecture.lecture_id) ? 'processing' : lecture.status
+          return (
+            <LectureCard
+              key={lecture.lecture_id}
+              lecture={{ ...lecture, status: effectiveStatus }}
+              isSelected={selectedIds.has(lecture.lecture_id)}
+              onToggleSelect={onToggleSelect}
+              onViewResults={onViewResults}
+              onProcessComplete={onProcessComplete}
+              onProcessError={onProcessError}
+              onRetry={onRetry}
+            />
+          )
+        })}
       </div>
 
       <WeekGuideCard
@@ -287,6 +300,155 @@ function WeekSection({
   )
 }
 
+// ── RightPanel ──
+
+interface RightPanelProps {
+  weeks: WeekSummary[]
+  selectedIds: Set<string>
+  processingLectures: Set<string>
+  processingWeeks: Set<number>
+  onDeselect: (lectureId: string) => void
+  onStartSelected: () => void
+  onViewResults: (lectureId: string) => void
+  onViewWeekResults: (week: number) => void
+  onProcessWeek: (week: number) => void
+}
+
+function RightPanel({
+  weeks,
+  selectedIds,
+  processingLectures,
+  processingWeeks,
+  onDeselect,
+  onStartSelected,
+  onViewResults,
+  onViewWeekResults,
+  onProcessWeek,
+}: RightPanelProps) {
+  // 모든 강의 플랫 리스트
+  const allLectures = weeks.flatMap((w) => w.lectures)
+
+  // 선택된 강의 (idle)
+  const selectedLectures = allLectures.filter((l) => selectedIds.has(l.lecture_id))
+
+  // 분석 완료된 강의
+  const completedLectures = allLectures.filter((l) => l.status === 'completed')
+
+  return (
+    <aside className="tml-right-panel">
+      {/* 분석 대기 */}
+      <div className="tml-right-panel__section">
+        <p className="tml-right-panel__section-title">
+          분석 대기 ({selectedIds.size}개)
+        </p>
+        {selectedLectures.length === 0 ? (
+          <p className="tml-right-panel__empty">강의를 선택하세요</p>
+        ) : (
+          <ul className="tml-right-panel__list">
+            {selectedLectures.map((l) => (
+              <li key={l.lecture_id} className="tml-right-panel__item">
+                <span className="tml-right-panel__item-label">
+                  {l.date.slice(5)} ({l.day_of_week})
+                </span>
+                <button
+                  className="tml-right-panel__remove"
+                  onClick={() => onDeselect(l.lecture_id)}
+                  aria-label="선택 해제"
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <button
+          className="btn-primary"
+          style={{
+            width: '100%',
+            marginTop: 12,
+            fontSize: '0.8125rem',
+            padding: '8px 14px',
+            opacity: selectedIds.size === 0 ? 0.4 : 1,
+            cursor: selectedIds.size === 0 ? 'not-allowed' : 'pointer',
+          }}
+          disabled={selectedIds.size === 0}
+          onClick={onStartSelected}
+        >
+          분석 시작 →
+        </button>
+      </div>
+
+      {/* 분석 완료 */}
+      <div className="tml-right-panel__section">
+        <p className="tml-right-panel__section-title">
+          분석 완료 ({completedLectures.length}개)
+        </p>
+        {completedLectures.length === 0 ? (
+          <p className="tml-right-panel__empty">완료된 강의 없음</p>
+        ) : (
+          <ul className="tml-right-panel__list">
+            {completedLectures.map((l) => (
+              <li key={l.lecture_id} className="tml-right-panel__item">
+                <span className="tml-right-panel__item-label">
+                  {l.date.slice(5)} ({l.day_of_week})
+                </span>
+                <button
+                  className="tml-lecture-card__result-btn"
+                  style={{ fontSize: '0.75rem' }}
+                  onClick={() => onViewResults(l.lecture_id)}
+                >
+                  결과보기→
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* 학습 가이드 */}
+      <div className="tml-right-panel__section">
+        <p className="tml-right-panel__section-title">학습 가이드</p>
+        {weeks.length === 0 ? (
+          <p className="tml-right-panel__empty">데이터 없음</p>
+        ) : (
+          <ul className="tml-right-panel__list">
+            {weeks.map((w) => {
+              const effectiveStatus: ProcessingStatus = processingWeeks.has(w.week)
+                ? 'processing'
+                : w.status === 'processing' && !processingWeeks.has(w.week)
+                  ? 'idle'
+                  : w.status
+              return (
+                <li key={w.week} className="tml-right-panel__item">
+                  <span className="tml-right-panel__item-label">{w.week}주차</span>
+                  {effectiveStatus === 'completed' ? (
+                    <button
+                      className="tml-lecture-card__result-btn"
+                      style={{ fontSize: '0.75rem' }}
+                      onClick={() => onViewWeekResults(w.week)}
+                    >
+                      완료 →
+                    </button>
+                  ) : effectiveStatus === 'processing' ? (
+                    <span style={{ fontSize: '0.75rem', color: 'var(--tml-ink-muted)' }}>분석 중…</span>
+                  ) : (
+                    <button
+                      className="tml-right-panel__guide-btn"
+                      onClick={() => onProcessWeek(w.week)}
+                    >
+                      생성 →
+                    </button>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  )
+}
+
 // ── LecturesPage (메인 export) ──
 
 export function LecturesPage() {
@@ -295,6 +457,7 @@ export function LecturesPage() {
   const [error, setError] = useState<string | null>(null)
   const [processingLectures, setProcessingLectures] = useState<Set<string>>(new Set())
   const [processingWeeks, setProcessingWeeks] = useState<Set<number>>(new Set())
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
 
@@ -311,16 +474,49 @@ export function LecturesPage() {
 
   const handleWeekSelect = useCallback(
     (week: number | null) => {
-      if (week === null) {
-        setSearchParams({})
-      } else {
-        setSearchParams({ week: String(week) })
-      }
+      if (week === null) setSearchParams({})
+      else setSearchParams({ week: String(week) })
     },
     [setSearchParams],
   )
 
-  const handleProcess = useCallback(async (lectureId: string) => {
+  const handleToggleSelect = useCallback((lectureId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(lectureId)) next.delete(lectureId)
+      else next.add(lectureId)
+      return next
+    })
+  }, [])
+
+  const handleDeselect = useCallback((lectureId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      next.delete(lectureId)
+      return next
+    })
+  }, [])
+
+  const handleStartSelected = useCallback(async () => {
+    const ids = [...selectedIds]
+    setSelectedIds(new Set())
+    await Promise.all(
+      ids.map(async (id) => {
+        setProcessingLectures((prev) => new Set(prev).add(id))
+        try {
+          await triggerLectureProcess(id)
+        } catch {
+          setProcessingLectures((prev) => {
+            const next = new Set(prev)
+            next.delete(id)
+            return next
+          })
+        }
+      }),
+    )
+  }, [selectedIds])
+
+  const handleRetry = useCallback(async (lectureId: string) => {
     setProcessingLectures((prev) => new Set(prev).add(lectureId))
     try {
       await triggerLectureProcess(lectureId)
@@ -391,7 +587,7 @@ export function LecturesPage() {
     activeWeek !== null ? weeks.filter((w) => w.week === activeWeek) : weeks
 
   return (
-    <main style={{ maxWidth: 1120, margin: '0 auto', padding: '40px 40px 80px' }}>
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
 
       {/* 페이지 헤더 */}
       <div className="tml-animate">
@@ -432,47 +628,54 @@ export function LecturesPage() {
         <ErrorCard message={error} title="강의 목록 로드 실패" />
       )}
 
-      {/* 필터 + 주차 목록 */}
+      {/* 분할 패널 레이아웃 */}
       {!loading && !error && (
         <>
           {weeks.length === 0 ? (
-            <div
-              className="tml-empty"
-              style={{ padding: '48px 24px', textAlign: 'center' }}
-            >
-              <p style={{
-                fontFamily: 'var(--font-body)',
-                color: 'var(--tml-ink-muted)',
-                margin: 0,
-              }}>
+            <div className="tml-empty" style={{ padding: '48px 24px', textAlign: 'center' }}>
+              <p style={{ fontFamily: 'var(--font-body)', color: 'var(--tml-ink-muted)', margin: 0 }}>
                 등록된 강의가 없습니다.
               </p>
             </div>
           ) : (
             <>
-              <WeekFilter
-                weeks={weekNumbers}
-                activeWeek={activeWeek}
-                onSelect={handleWeekSelect}
-              />
+              <WeekFilter weeks={weekNumbers} activeWeek={activeWeek} onSelect={handleWeekSelect} />
 
-              <div className="tml-week-content" style={{ display: 'flex', flexDirection: 'column', gap: 48 }}>
-                {filteredWeeks.map((weekSummary) => (
-                  <WeekSection
-                    key={weekSummary.week}
-                    weekSummary={weekSummary}
-                    processingLectures={processingLectures}
-                    processingWeeks={processingWeeks}
-                    onProcess={handleProcess}
-                    onViewResults={(id) => navigate(`/lecture/${id}`)}
-                    onProcessComplete={handleProcessComplete}
-                    onProcessError={handleProcessError}
-                    onProcessWeek={handleProcessWeek}
-                    onViewWeekResults={(w) => navigate(`/weekly/${w}`)}
-                    onWeekProcessComplete={handleWeekProcessComplete}
-                    onWeekProcessError={handleWeekProcessError}
-                  />
-                ))}
+              <div className="tml-split-layout">
+                {/* 왼쪽: 강의 목록 */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 48 }}>
+                  {filteredWeeks.map((weekSummary) => (
+                    <WeekSection
+                      key={weekSummary.week}
+                      weekSummary={weekSummary}
+                      processingLectures={processingLectures}
+                      processingWeeks={processingWeeks}
+                      selectedIds={selectedIds}
+                      onToggleSelect={handleToggleSelect}
+                      onViewResults={(id) => navigate(`/lecture/${id}`)}
+                      onProcessComplete={handleProcessComplete}
+                      onProcessError={handleProcessError}
+                      onRetry={handleRetry}
+                      onProcessWeek={handleProcessWeek}
+                      onViewWeekResults={(w) => navigate(`/weekly/${w}`)}
+                      onWeekProcessComplete={handleWeekProcessComplete}
+                      onWeekProcessError={handleWeekProcessError}
+                    />
+                  ))}
+                </div>
+
+                {/* 오른쪽: 분석 현황 패널 */}
+                <RightPanel
+                  weeks={weeks}
+                  selectedIds={selectedIds}
+                  processingLectures={processingLectures}
+                  processingWeeks={processingWeeks}
+                  onDeselect={handleDeselect}
+                  onStartSelected={handleStartSelected}
+                  onViewResults={(id) => navigate(`/lecture/${id}`)}
+                  onViewWeekResults={(w) => navigate(`/weekly/${w}`)}
+                  onProcessWeek={handleProcessWeek}
+                />
               </div>
             </>
           )}


### PR DESCRIPTION
## 요약

- 강의 카드 클릭으로 분석 대기 목록에 선택/해제 (idle 상태만)
- 우측 고정 패널에서 선택된 강의 확인 후 일괄 분석 시작
- 분석 완료 강의·주차별 학습 가이드 상태도 우측 패널에서 바로 접근 가능
- 분할 그리드 레이아웃(`tml-split-layout`) 및 선택 인터랙션 스타일 추가

## 변경 파일

- `frontend/src/pages/LecturesPage.tsx` — RightPanel 컴포넌트 신규, 선택 상태 관리 로직
- `frontend/src/index.css` — 분할 패널·체크박스·선택 카드 스타일
- `CLAUDE.md` — 디렉터리 구조·커맨드·태스크 파일 규칙·환경변수 섹션 보완

## 테스트 플랜

- [ ] idle 카드 클릭 → 선택 표시 (오렌지 아웃라인 + 체크 뱃지)
- [ ] 동일 카드 재클릭 → 선택 해제
- [ ] 우측 패널 `분석 시작 →` 버튼 → 선택된 강의 일괄 처리 시작
- [ ] 우측 패널 ✕ 버튼 → 개별 선택 해제
- [ ] completed 카드 클릭 → 결과 페이지 이동
- [ ] 900px 이하에서 단일 컬럼 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)