### PR TITLE
fix: RightPanel 미사용 processingLectures prop 제거 (TS6133)

### DIFF
--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -305,7 +305,6 @@ function WeekSection({
 interface RightPanelProps {
   weeks: WeekSummary[]
   selectedIds: Set<string>
-  processingLectures: Set<string>
   processingWeeks: Set<number>
   onDeselect: (lectureId: string) => void
   onStartSelected: () => void
@@ -317,7 +316,6 @@ interface RightPanelProps {
 function RightPanel({
   weeks,
   selectedIds,
-  processingLectures,
   processingWeeks,
   onDeselect,
   onStartSelected,
@@ -668,7 +666,6 @@ export function LecturesPage() {
                 <RightPanel
                   weeks={weeks}
                   selectedIds={selectedIds}
-                  processingLectures={processingLectures}
                   processingWeeks={processingWeeks}
                   onDeselect={handleDeselect}
                   onStartSelected={handleStartSelected}


### PR DESCRIPTION
## 요약

- `RightPanel` 컴포넌트에 전달되던 `processingLectures` prop이 내부에서 사용되지 않아 TypeScript TS6133 오류 발생
- interface 및 구조분해, 호출부에서 해당 prop 제거

## 테스트 플랜

- [ ] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)