### PR TITLE
fix: 이미 완료된 강의 재분석 시 409 에러 수정

### DIFF
--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -502,7 +502,7 @@ export function LecturesPage() {
       ids.map(async (id) => {
         setProcessingLectures((prev) => new Set(prev).add(id))
         try {
-          await triggerLectureProcess(id)
+          await triggerLectureProcess(id, true)
         } catch {
           setProcessingLectures((prev) => {
             const next = new Set(prev)


### PR DESCRIPTION
## 요약
- 분석 시작 버튼 클릭 시 `triggerLectureProcess`에 `force=true` 전달
- 이미 처리 완료(`completed`)된 강의를 다시 선택해 분석해도 409 에러 없이 재처리됨

## 원인
백엔드는 completed 상태 강의에 `/process` 요청이 오면 `?force=true` 없이는 409 Conflict를 반환함.
프론트에서 `force` 파라미터를 전달하지 않아 발생.

## 테스트
- 이미 분석된 강의 선택 후 분석 시작 → 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)