### PR TITLE
fix: 분석 완료 후 결과 페이지에서 '미분석' 표시 오류 수정

### DIFF
--- a/frontend/src/pages/LectureResult.tsx
+++ b/frontend/src/pages/LectureResult.tsx
@@ -6,6 +6,7 @@ import { ProcessingStatus } from '../components/ProcessingStatus'
 import {
   fetchLecture,
   fetchLectureResults,
+  fetchLectureStatus,
   triggerLectureProcess,
   ApiError,
 } from '../services/api'
@@ -43,14 +44,22 @@ export function LectureResult() {
       }
       setState({ tag: 'loading' })
       try {
-        const lecture = await fetchLecture(id!)
+        const [lecture, jobStatus] = await Promise.all([
+          fetchLecture(id!),
+          fetchLectureStatus(id!).catch(() => null),
+        ])
         if (cancelled) return
 
-        if (lecture.status === 'completed') {
+        const isCompleted =
+          lecture.status === 'completed' || jobStatus?.status === 'completed'
+        const isProcessing =
+          lecture.status === 'processing' || jobStatus?.status === 'processing'
+
+        if (isCompleted) {
           const outputs = await fetchLectureResults(id!)
           if (cancelled) return
           setState({ tag: 'results', lecture, outputs })
-        } else if (lecture.status === 'processing') {
+        } else if (isProcessing) {
           setState({ tag: 'processing', lecture })
         } else {
           setState({ tag: 'not-processed', lecture })


### PR DESCRIPTION
## 요약
- `LectureResult` 페이지 진입 시 카탈로그 status뿐 아니라 `/status` 엔드포인트(인메모리 job state)도 함께 확인
- 시뮬레이션 완료 후 실제 파일이 없어도 결과 페이지가 정상 표시됨

## 원인
`/api/lectures/{id}` 카탈로그는 파일시스템 기반이라 시뮬레이션 완료 후에도 `pending` 상태를 반환.
인메모리 job state를 반환하는 `/status` 엔드포인트를 함께 확인하지 않아 "아직 분석되지 않았습니다" 화면이 표시됨.

## 테스트
- 강의 선택 → 분석 시작 → 완료 후 결과 페이지 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)