### PR TITLE
feat: 프론트엔드 UI 개선 — 대시보드·강의·인터랙티브 코드 퀴즈

### DIFF
--- a/data/dummy/quizzes.json
+++ b/data/dummy/quizzes.json
@@ -382,5 +382,72 @@
     "explanation": "dept_id 컬럼에 인덱스를 생성하면, WHERE dept_id = 10 조건 검색 시 옵티마이저가 인덱스를 활용하여 전체 테이블 스캔 없이 빠르게 해당 행을 찾습니다.",
     "validation_log": {"checked": true, "source": "dummy"},
     "meta": {"lecture_id": "2026-02-04_kdt-backendj-21th"}
+  },
+  {
+    "quiz_id": "quiz-031",
+    "status": "pass",
+    "type": "code",
+    "question": "두 수를 입력받아 합을 출력하는 함수를 완성하세요.",
+    "language": "python",
+    "starter_code": "def add(a, b):\n    # 여기에 코드를 작성하세요\n    pass\n\nprint(add(3, 5))\nprint(add(10, 20))\nprint(add(-1, 1))",
+    "expected_output": "8",
+    "test_cases": [
+      {"input": "3, 5", "expected_output": "8"},
+      {"input": "10, 20", "expected_output": "30"},
+      {"input": "-1, 1", "expected_output": "0"}
+    ],
+    "options": null,
+    "answer": "def add(a, b):\n    return a + b\n\nprint(add(3, 5))\nprint(add(10, 20))\nprint(add(-1, 1))",
+    "explanation": "함수에서 두 매개변수를 더한 값을 return으로 반환하면 됩니다. pass를 지우고 return a + b를 작성합니다.",
+    "validation_log": {"checked": true, "source": "dummy"},
+    "meta": {"lecture_id": "2026-02-02_kdt-backendj-21th"}
+  },
+  {
+    "quiz_id": "quiz-032",
+    "status": "pass",
+    "type": "code",
+    "question": "리스트에서 짝수만 필터링하여 출력하는 코드를 작성하세요.",
+    "language": "python",
+    "starter_code": "numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n\n# 짝수만 필터링하여 출력하세요\nevens = []\n\nprint(evens)",
+    "expected_output": "[2, 4, 6, 8, 10]",
+    "test_cases": [
+      {"expected_output": "[2, 4, 6, 8, 10]"}
+    ],
+    "options": null,
+    "answer": "numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n\nevens = [n for n in numbers if n % 2 == 0]\n\nprint(evens)",
+    "explanation": "리스트 컴프리헨션을 사용하여 n % 2 == 0 조건으로 짝수를 필터링합니다. for 루프로도 동일하게 구현할 수 있습니다.",
+    "validation_log": {"checked": true, "source": "dummy"},
+    "meta": {"lecture_id": "2026-02-02_kdt-backendj-21th"}
+  },
+  {
+    "quiz_id": "quiz-033",
+    "status": "pass",
+    "type": "code",
+    "question": "FizzBuzz: 1부터 15까지 숫자를 출력하되, 3의 배수는 'Fizz', 5의 배수는 'Buzz', 15의 배수는 'FizzBuzz'를 출력하세요.",
+    "language": "javascript",
+    "starter_code": "for (let i = 1; i <= 15; i++) {\n  // 여기에 조건문을 작성하세요\n  console.log(i);\n}",
+    "expected_output": "1",
+    "test_cases": [
+      {"expected_output": "1"},
+      {"expected_output": "2"},
+      {"expected_output": "Fizz"},
+      {"expected_output": "4"},
+      {"expected_output": "Buzz"},
+      {"expected_output": "Fizz"},
+      {"expected_output": "7"},
+      {"expected_output": "8"},
+      {"expected_output": "Fizz"},
+      {"expected_output": "Buzz"},
+      {"expected_output": "11"},
+      {"expected_output": "Fizz"},
+      {"expected_output": "13"},
+      {"expected_output": "14"},
+      {"expected_output": "FizzBuzz"}
+    ],
+    "options": null,
+    "answer": "for (let i = 1; i <= 15; i++) {\n  if (i % 15 === 0) console.log('FizzBuzz');\n  else if (i % 3 === 0) console.log('Fizz');\n  else if (i % 5 === 0) console.log('Buzz');\n  else console.log(i);\n}",
+    "explanation": "15의 배수(3과 5의 공배수)를 먼저 체크해야 합니다. 순서가 중요합니다 — 3이나 5를 먼저 체크하면 15의 배수가 'FizzBuzz' 대신 'Fizz'나 'Buzz'로 출력됩니다.",
+    "validation_log": {"checked": true, "source": "dummy"},
+    "meta": {"lecture_id": "2026-02-03_kdt-backendj-21th"}
   }
 ]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1"
@@ -816,6 +817,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -1564,6 +1588,14 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.1",
@@ -2389,6 +2421,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.321",
@@ -3397,6 +3439,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -3425,6 +3480,17 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -3902,6 +3968,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1"

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,0 +1,99 @@
+import { lazy, Suspense, useEffect, useState } from 'react'
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'))
+
+interface CodeEditorProps {
+  language: string
+  starterCode: string
+  onRun: (code: string) => void
+  running: boolean
+}
+
+const LANG_MAP: Record<string, string> = {
+  python: 'python',
+  javascript: 'javascript',
+  typescript: 'typescript',
+  java: 'java',
+  sql: 'sql',
+  c: 'c',
+  cpp: 'cpp',
+  go: 'go',
+  rust: 'rust',
+}
+
+function useTheme() {
+  const [dark, setDark] = useState(
+    () => document.documentElement.getAttribute('data-theme') === 'dark',
+  )
+  useEffect(() => {
+    const obs = new MutationObserver(() => {
+      setDark(document.documentElement.getAttribute('data-theme') === 'dark')
+    })
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
+    return () => obs.disconnect()
+  }, [])
+  return dark
+}
+
+export function CodeEditor({ language, starterCode, onRun, running }: CodeEditorProps) {
+  const [code, setCode] = useState(starterCode)
+  const dark = useTheme()
+
+  const handleReset = () => setCode(starterCode)
+
+  return (
+    <div className="code-editor">
+      <div className="code-editor__toolbar">
+        <span className="code-editor__lang-badge">
+          {language.toUpperCase()}
+        </span>
+        <div className="code-editor__actions">
+          <button
+            className="code-editor__btn code-editor__btn--reset"
+            onClick={handleReset}
+            disabled={running}
+          >
+            초기화
+          </button>
+          <button
+            className="code-editor__btn code-editor__btn--run"
+            onClick={() => onRun(code)}
+            disabled={running}
+          >
+            {running ? (
+              <span className="code-editor__spinner" />
+            ) : (
+              '▶'
+            )}
+            {running ? '실행 중…' : '실행'}
+          </button>
+        </div>
+      </div>
+
+      <Suspense
+        fallback={
+          <div className="code-editor__loading">에디터 로딩 중…</div>
+        }
+      >
+        <MonacoEditor
+          height="220px"
+          language={LANG_MAP[language] ?? 'plaintext'}
+          theme={dark ? 'vs-dark' : 'light'}
+          value={code}
+          onChange={(v) => setCode(v ?? '')}
+          options={{
+            minimap: { enabled: false },
+            fontSize: 13,
+            fontFamily: 'var(--font-mono)',
+            lineNumbers: 'on',
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            tabSize: 4,
+            wordWrap: 'on',
+            padding: { top: 12, bottom: 12 },
+          }}
+        />
+      </Suspense>
+    </div>
+  )
+}

--- a/frontend/src/components/OutputPanel.tsx
+++ b/frontend/src/components/OutputPanel.tsx
@@ -1,0 +1,95 @@
+import type { QuizTestCase } from '../types/models'
+
+export interface TestResult {
+  input?: string
+  expected: string
+  actual: string
+  passed: boolean
+}
+
+interface OutputPanelProps {
+  stdout: string | null
+  stderr: string | null
+  testResults: TestResult[] | null
+  error: string | null
+}
+
+export function runTestCases(
+  stdout: string,
+  testCases: QuizTestCase[],
+): TestResult[] {
+  const outputLines = stdout.trimEnd().split('\n')
+
+  return testCases.map((tc, i) => {
+    const actual = (outputLines[i] ?? '').trim()
+    const expected = tc.expected_output.trim()
+    return {
+      input: tc.input,
+      expected,
+      actual,
+      passed: actual === expected,
+    }
+  })
+}
+
+export function OutputPanel({ stdout, stderr, testResults, error }: OutputPanelProps) {
+  if (error) {
+    return (
+      <div className="output-panel">
+        <div className="output-panel__header">실행 결과</div>
+        <pre className="output-panel__error">{error}</pre>
+      </div>
+    )
+  }
+
+  if (stdout === null && stderr === null && !testResults) return null
+
+  const allPassed = testResults?.every((r) => r.passed) ?? false
+
+  return (
+    <div className="output-panel">
+      <div className="output-panel__header">실행 결과</div>
+
+      {stdout !== null && stdout.length > 0 && (
+        <pre className="output-panel__stdout">{stdout}</pre>
+      )}
+
+      {stderr !== null && stderr.length > 0 && (
+        <pre className="output-panel__error">{stderr}</pre>
+      )}
+
+      {testResults && testResults.length > 0 && (
+        <div className="output-panel__tests">
+          <div className="output-panel__tests-header">
+            {allPassed ? '✓ 모든 테스트 통과!' : `✗ ${testResults.filter((r) => !r.passed).length}개 실패`}
+          </div>
+          <div className="output-panel__tests-list">
+            {testResults.map((r, i) => (
+              <div
+                key={i}
+                className={`output-panel__test ${r.passed ? 'output-panel__test--pass' : 'output-panel__test--fail'}`}
+              >
+                <span className="output-panel__test-icon">{r.passed ? '✓' : '✗'}</span>
+                <div className="output-panel__test-detail">
+                  {r.input && (
+                    <span className="output-panel__test-label">
+                      입력: <code>{r.input}</code>
+                    </span>
+                  )}
+                  <span className="output-panel__test-label">
+                    기대: <code>{r.expected}</code>
+                  </span>
+                  {!r.passed && (
+                    <span className="output-panel__test-label output-panel__test-label--actual">
+                      실제: <code>{r.actual}</code>
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/QuizCard.tsx
+++ b/frontend/src/components/QuizCard.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react'
 import type { Quiz } from '../types/models'
+import { CodeEditor } from './CodeEditor'
+import { OutputPanel, runTestCases } from './OutputPanel'
+import type { TestResult } from './OutputPanel'
+import { executeCode } from '../services/piston'
 
 interface QuizCardProps {
   quiz: Quiz
@@ -224,8 +228,8 @@ function FillCard({ quiz, quizIndex, totalInType }: QuizCardProps) {
   )
 }
 
-/* ── CODE: 코드 뷰어형 ───────────────────────────────── */
-function CodeCard({ quiz, quizIndex, totalInType }: QuizCardProps) {
+/* ── CODE (정적): 코드 뷰어형 ────────────────────────── */
+function StaticCodeCard({ quiz, quizIndex, totalInType }: QuizCardProps) {
   const [showAnswer, setShowAnswer] = useState(false)
 
   return (
@@ -258,6 +262,101 @@ function CodeCard({ quiz, quizIndex, totalInType }: QuizCardProps) {
       )}
     </div>
   )
+}
+
+/* ── CODE (인터랙티브): 에디터 + 실행 + 채점 ─────────── */
+function InteractiveCodeCard({ quiz, quizIndex, totalInType }: QuizCardProps) {
+  const [running, setRunning] = useState(false)
+  const [stdout, setStdout] = useState<string | null>(null)
+  const [stderr, setStderr] = useState<string | null>(null)
+  const [testResults, setTestResults] = useState<TestResult[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [showAnswer, setShowAnswer] = useState(false)
+
+  const allPassed = testResults?.every((r) => r.passed) ?? false
+  const hasResult = stdout !== null || stderr !== null || error !== null
+
+  const handleRun = async (code: string) => {
+    setRunning(true)
+    setStdout(null)
+    setStderr(null)
+    setTestResults(null)
+    setError(null)
+
+    try {
+      const res = await executeCode(quiz.language ?? 'python', code)
+      const out = res.run.stdout
+      const err = res.compile?.stderr || res.run.stderr
+
+      setStdout(out)
+      setStderr(err || null)
+
+      if (quiz.test_cases && quiz.test_cases.length > 0) {
+        setTestResults(runTestCases(out, quiz.test_cases))
+      } else if (quiz.expected_output) {
+        setTestResults(runTestCases(out, [{ expected_output: quiz.expected_output }]))
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '코드 실행 중 오류가 발생했습니다.')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <div className="tml-card quiz-type-card">
+      <div className="quiz-type-card__meta">
+        <span className="quiz-badge quiz-badge--code">코드 실행</span>
+        <span className="quiz-meta-id">
+          {quizIndex + 1} / {totalInType} · Q-{String(quizIndex + 1).padStart(3, '0')}
+        </span>
+      </div>
+
+      <p className="quiz-question">{quiz.question}</p>
+
+      <CodeEditor
+        language={quiz.language ?? 'python'}
+        starterCode={quiz.starter_code ?? ''}
+        onRun={handleRun}
+        running={running}
+      />
+
+      <OutputPanel
+        stdout={stdout}
+        stderr={stderr}
+        testResults={testResults}
+        error={error}
+      />
+
+      {hasResult && testResults && (
+        <div className={`quiz-feedback ${allPassed ? 'quiz-feedback--correct' : 'quiz-feedback--wrong'}`}>
+          {allPassed ? '✓ 정답입니다!' : '✗ 테스트를 통과하지 못했습니다.'}
+        </div>
+      )}
+
+      <button className="quiz-reset-btn" onClick={() => setShowAnswer((s) => !s)}>
+        정답 보기 {showAnswer ? '▴' : '▾'}
+      </button>
+
+      {showAnswer && (
+        <div style={{ marginTop: 16 }}>
+          <pre className="quiz-code-block quiz-code-block--answer"><code>{answerStr(quiz.answer)}</code></pre>
+          <div className="quiz-explanation">
+            <span className="quiz-explanation__icon">💡</span>
+            <p className="quiz-explanation__text">{quiz.explanation}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── CODE: 분기 — starter_code 유무로 인터랙티브/정적 결정 */
+function CodeCard(props: QuizCardProps) {
+  if (props.quiz.starter_code) {
+    return <InteractiveCodeCard {...props} />
+  }
+  return <StaticCodeCard {...props} />
 }
 
 /* ── 진입점 ──────────────────────────────────────────── */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -678,6 +678,210 @@ body::after {
   margin-bottom: 16px;
 }
 
+/* === 인터랙티브 코드 에디터 === */
+
+.code-editor {
+  border: 1px solid var(--tml-rule);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.code-editor__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--tml-bg-overlay);
+  border-bottom: 1px solid var(--tml-rule);
+}
+
+.code-editor__lang-badge {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--tml-quiz-code);
+  background: var(--tml-quiz-code-bg);
+  padding: 2px 8px;
+  border-radius: 4px;
+  letter-spacing: 0.06em;
+}
+
+.code-editor__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.code-editor__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.code-editor__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.code-editor__btn--reset {
+  background: var(--tml-bg-raised);
+  color: var(--tml-ink-muted);
+  border: 1px solid var(--tml-rule);
+}
+
+.code-editor__btn--reset:hover:not(:disabled) {
+  background: var(--tml-bg-overlay);
+}
+
+.code-editor__btn--run {
+  background: var(--tml-quiz-code);
+  color: var(--tml-white);
+}
+
+.code-editor__btn--run:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.code-editor__spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: var(--tml-white);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.code-editor__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 220px;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: var(--tml-ink-muted);
+  background: var(--tml-bg-raised);
+}
+
+/* === 실행 결과 패널 === */
+
+.output-panel {
+  border: 1px solid var(--tml-rule);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.output-panel__header {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tml-ink-muted);
+  padding: 8px 12px;
+  background: var(--tml-bg-overlay);
+  border-bottom: 1px solid var(--tml-rule);
+}
+
+.output-panel__stdout {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--tml-ink);
+  padding: 12px;
+  margin: 0;
+  background: var(--tml-bg-raised);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.output-panel__error {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--tml-wrong, #E53E3E);
+  padding: 12px;
+  margin: 0;
+  background: var(--tml-bg-raised);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.output-panel__tests {
+  border-top: 1px solid var(--tml-rule);
+}
+
+.output-panel__tests-header {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 8px 12px;
+  background: var(--tml-bg-overlay);
+}
+
+.output-panel__tests-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.output-panel__test {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  border-top: 1px solid var(--tml-rule);
+}
+
+.output-panel__test--pass .output-panel__test-icon {
+  color: var(--tml-correct, #38A169);
+}
+
+.output-panel__test--fail .output-panel__test-icon {
+  color: var(--tml-wrong, #E53E3E);
+}
+
+.output-panel__test-icon {
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.output-panel__test-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.output-panel__test-label {
+  color: var(--tml-ink-secondary);
+}
+
+.output-panel__test-label code {
+  color: var(--tml-ink);
+  background: var(--tml-bg-overlay);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.output-panel__test-label--actual code {
+  color: var(--tml-wrong, #E53E3E);
+}
+
 /* 다시 보기 / 정답 보기 공통 버튼 */
 .quiz-reset-btn {
   background: none;

--- a/frontend/src/services/piston.ts
+++ b/frontend/src/services/piston.ts
@@ -1,0 +1,62 @@
+const PISTON_URL = 'https://emkc.org/api/v2/piston/execute'
+const TIMEOUT_MS = 10_000
+
+export interface PistonRunResult {
+  stdout: string
+  stderr: string
+  code: number
+  signal: string | null
+}
+
+export interface PistonResponse {
+  run: PistonRunResult
+  compile?: PistonRunResult
+}
+
+const LANGUAGE_VERSIONS: Record<string, string> = {
+  python: '3.10.0',
+  javascript: '18.15.0',
+  java: '15.0.2',
+  sql: '*',
+  typescript: '5.0.3',
+  c: '10.2.0',
+  cpp: '10.2.0',
+  go: '1.16.2',
+  rust: '1.68.2',
+}
+
+export async function executeCode(
+  language: string,
+  code: string,
+  stdin?: string,
+): Promise<PistonResponse> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    const res = await fetch(PISTON_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        language,
+        version: LANGUAGE_VERSIONS[language] ?? '*',
+        files: [{ content: code }],
+        stdin: stdin ?? '',
+      }),
+    })
+
+    if (!res.ok) {
+      throw new Error(`Piston API error: ${res.status}`)
+    }
+
+    return (await res.json()) as PistonResponse
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('코드 실행 시간이 초과되었습니다 (10초)')
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -75,6 +75,11 @@ export interface LearningPoint {
   meta: Record<string, unknown>
 }
 
+export interface QuizTestCase {
+  input?: string
+  expected_output: string
+}
+
 export interface Quiz {
   quiz_id: string
   status: 'pass' | 'fail'
@@ -84,6 +89,10 @@ export interface Quiz {
   answer: string | string[] | null
   explanation: string | null
   code?: string
+  language?: string
+  starter_code?: string
+  expected_output?: string
+  test_cases?: QuizTestCase[]
   validation_log: Record<string, unknown>
   meta: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary
- 대시보드 리디자인: 프로그레스 링, 히트맵, 개념 클라우드 추가
- 강의 페이지 분할 패널 레이아웃 및 선택 분석 UI 구현
- 인터랙티브 코드 퀴즈: Monaco 에디터 + Piston API 코드 실행·채점
- LectureResult 강의 상태 판단 버그 수정 및 기타 fix

## 변경 파일
- `frontend/src/components/CodeEditor.tsx` — Monaco 에디터 컴포넌트 (신규)
- `frontend/src/components/OutputPanel.tsx` — 실행 결과·채점 패널 (신규)
- `frontend/src/services/piston.ts` — Piston API 연동 (신규)
- `frontend/src/components/QuizCard.tsx` — 인터랙티브/정적 코드 카드 분기
- `frontend/src/types/models.ts` — 코드 퀴즈 타입 확장
- `frontend/src/index.css` — 에디터·결과 패널 스타일
- `data/dummy/quizzes.json` — 코드형 더미 퀴즈 추가

## Test plan
- [ ] 대시보드 페이지 렌더링 확인
- [ ] 강의 페이지 분할 패널 동작 확인
- [ ] 코드 퀴즈 에디터 작성 → 실행 → 채점 플로우
- [ ] starter_code 없는 퀴즈는 기존 정적 코드 카드로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)