### PR TITLE
feat: 대시보드 리디자인 — 다크 히어로·벤토 그리드·타일 카드

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1252,57 +1252,167 @@ body::after {
   .tml-dashboard-stagger { animation: none; }
 }
 
-/* ── 히어로: 프로그레스 링 + 환영 ── */
-.tml-dashboard-hero {
-  display: flex;
-  align-items: center;
-  gap: 40px;
-  padding: 32px 36px;
-  background: var(--tml-bg-raised);
-  border: 1px solid var(--tml-rule);
-  border-radius: 10px;
-  margin-bottom: 28px;
+/* ── 히어로 (다크 네이비) ── */
+.tml-hero {
   position: relative;
+  background: linear-gradient(135deg, var(--tml-navy) 0%, #1A3558 60%, #0D2240 100%);
+  border-radius: 16px;
+  padding: 44px 40px 20px;
+  margin-bottom: 24px;
   overflow: hidden;
 }
 
-.tml-dashboard-hero::before {
-  content: '';
+.tml-hero__decor {
   position: absolute;
-  top: -40px;
-  right: -20px;
-  width: 260px;
-  height: 260px;
-  background: radial-gradient(circle, rgba(255, 107, 0, 0.06), transparent 70%);
+  inset: 0;
   pointer-events: none;
 }
 
-.tml-dashboard-hero__text {
+.tml-hero__ring {
+  position: absolute;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 107, 0, 0.12);
+}
+
+.tml-hero__ring--1 {
+  width: 340px;
+  height: 340px;
+  top: -120px;
+  right: -60px;
+}
+
+.tml-hero__ring--2 {
+  width: 220px;
+  height: 220px;
+  top: -60px;
+  right: 0;
+}
+
+.tml-hero__ring--3 {
+  width: 120px;
+  height: 120px;
+  bottom: -40px;
+  left: -30px;
+  border-color: rgba(255, 255, 255, 0.04);
+}
+
+.tml-hero__glow {
+  position: absolute;
+  width: 480px;
+  height: 480px;
+  top: -50%;
+  right: -5%;
+  background: radial-gradient(circle, rgba(255, 107, 0, 0.1), transparent 65%);
+}
+
+.tml-hero__content {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 40px;
+  z-index: 1;
+}
+
+.tml-hero__info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
-.tml-dashboard-hero__greeting {
+.tml-hero__eyebrow {
+  font-family: var(--font-body);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--tml-orange);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin: 0;
+  opacity: 0.9;
+}
+
+.tml-hero__title {
   font-family: var(--font-display);
   font-weight: 700;
-  font-size: 1.25rem;
-  color: var(--tml-ink);
+  font-size: 1.5rem;
+  color: #fff;
   margin: 0;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
 }
 
-.tml-dashboard-hero__summary {
+.tml-hero__desc {
   font-family: var(--font-body);
   font-size: 0.9375rem;
-  color: var(--tml-ink-secondary);
+  color: rgba(255, 255, 255, 0.6);
   margin: 0;
-  line-height: 1.7;
+  line-height: 1.6;
 }
 
-.tml-dashboard-hero__summary strong {
-  color: var(--tml-ink);
+.tml-hero__desc strong {
+  color: rgba(255, 255, 255, 0.9);
   font-weight: 600;
+}
+
+.tml-hero__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 9px 22px;
+  background: var(--tml-orange);
+  color: #fff;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.15s ease;
+  width: fit-content;
+}
+
+.tml-hero__cta:hover {
+  background: var(--tml-orange-dark);
+  transform: translateY(-1px);
+}
+
+.tml-hero__cta-arrow {
+  transition: transform 0.2s ease;
+}
+
+.tml-hero__cta:hover .tml-hero__cta-arrow {
+  transform: translateX(3px);
+}
+
+.tml-hero__bar {
+  position: relative;
+  margin-top: 28px;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.tml-hero__bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--tml-orange), #FF9F4A);
+  border-radius: 2px;
+  transition: width 1.5s cubic-bezier(0.16, 1, 0.3, 1) 0.3s;
+}
+
+/* 히어로 안 프로그레스 링 색상 오버라이드 */
+.tml-hero .tml-progress-ring__percent { color: #fff; }
+.tml-hero .tml-progress-ring__unit { color: rgba(255, 255, 255, 0.45); }
+.tml-hero .tml-progress-ring__svg circle:first-of-type { stroke: rgba(255, 255, 255, 0.1); }
+
+[data-theme="dark"] .tml-hero {
+  background: linear-gradient(135deg, #0D1B2E 0%, #152942 60%, #0A1628 100%);
+  border: 1px solid rgba(255, 107, 0, 0.06);
+}
+
+@media (max-width: 768px) {
+  .tml-hero { padding: 32px 24px 16px; }
+  .tml-hero__content { flex-direction: column; gap: 24px; text-align: center; align-items: center; }
+  .tml-hero__info { align-items: center; }
 }
 
 /* ── 프로그레스 링 ── */
@@ -1350,46 +1460,76 @@ body::after {
   margin-top: 4px;
 }
 
-/* ── 통계 카드 (4개) ── */
-.tml-dashboard-stats {
+/* ── 벤토 그리드 ── */
+.tml-bento {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: 1fr 1fr 2fr;
+  grid-template-rows: auto auto;
   gap: 12px;
   margin-bottom: 32px;
 }
 
-@media (max-width: 768px) {
-  .tml-dashboard-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
+.tml-bento > .tml-stat:nth-child(1) { grid-column: 1; grid-row: 1; }
+.tml-bento > .tml-stat:nth-child(2) { grid-column: 2; grid-row: 1; }
+.tml-bento > .tml-stat:nth-child(3) { grid-column: 1; grid-row: 2; }
+.tml-bento > .tml-stat:nth-child(4) { grid-column: 2; grid-row: 2; }
+
+.tml-bento__map {
+  grid-column: 3;
+  grid-row: 1 / 3;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.tml-stat-card {
-  padding: 18px 20px;
-  border-top: 2px solid var(--tml-orange);
+.tml-bento__map-label {
+  font-family: var(--font-body);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--tml-ink-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .tml-bento {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto auto;
+  }
+  .tml-bento > .tml-stat:nth-child(1) { grid-column: 1; grid-row: 1; }
+  .tml-bento > .tml-stat:nth-child(2) { grid-column: 2; grid-row: 1; }
+  .tml-bento > .tml-stat:nth-child(3) { grid-column: 1; grid-row: 2; }
+  .tml-bento > .tml-stat:nth-child(4) { grid-column: 2; grid-row: 2; }
+  .tml-bento__map { grid-column: 1 / -1; grid-row: 3; }
+}
+
+/* ── 통계 카드 ── */
+.tml-stat {
+  background: var(--tml-bg-raised);
+  border: 1px solid var(--tml-rule);
+  border-radius: 12px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.tml-stat-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 6px 20px rgba(15, 31, 61, 0.08);
+.tml-stat:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(15, 31, 61, 0.06);
+  border-color: var(--tml-rule-strong);
 }
 
-.tml-stat-card__header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.tml-stat__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
 }
 
-.tml-stat-card__icon {
-  font-size: 1rem;
-  line-height: 1;
-}
-
-.tml-stat-card__label {
+.tml-stat__label {
   font-family: var(--font-body);
   font-size: 0.75rem;
   color: var(--tml-ink-muted);
@@ -1397,88 +1537,110 @@ body::after {
   letter-spacing: 0.02em;
 }
 
-.tml-stat-card__value {
-  font-family: var(--font-mono);
-  font-size: 1.75rem;
-  font-weight: 600;
+.tml-stat__value {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
   color: var(--tml-ink);
   line-height: 1;
+  letter-spacing: -0.02em;
 }
 
-/* ── 2컬럼 그리드 ── */
-.tml-dashboard-grid {
+/* ── 최근 강의 타일 (3열 그리드) ── */
+.tml-recent-grid {
   display: grid;
-  grid-template-columns: minmax(0, 5fr) minmax(0, 3fr);
-  gap: 32px;
-  margin-top: 4px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
 }
 
 @media (max-width: 768px) {
-  .tml-dashboard-grid {
-    grid-template-columns: 1fr;
-  }
+  .tml-recent-grid { grid-template-columns: 1fr; }
 }
 
-/* ── 최근 완료 카드 ── */
-.tml-recent-card {
+.tml-lecture-tile {
   display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 16px 20px;
+  flex-direction: column;
+  padding: 20px;
   text-decoration: none;
   color: inherit;
-  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  border-top: 3px solid var(--tml-orange);
+  border-radius: 2px 2px 6px 6px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.tml-recent-card:hover {
-  border-color: var(--tml-orange);
-  box-shadow: 0 2px 8px var(--tml-shadow-hover);
-  transform: translateY(-1px);
+.tml-lecture-tile:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(15, 31, 61, 0.08);
 }
 
-.tml-recent-card__badge {
-  width: 44px;
-  height: 44px;
-  border-radius: 8px;
-  background: var(--tml-orange);
+.tml-lecture-tile__header {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  justify-content: center;
+  margin-bottom: 14px;
+}
+
+.tml-lecture-tile__week {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
   color: #fff;
+  background: var(--tml-navy);
+  padding: 3px 10px;
+  border-radius: 4px;
+  letter-spacing: 0.04em;
+}
+
+.tml-lecture-tile__arrow {
+  font-size: 0.875rem;
+  color: var(--tml-orange);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.tml-lecture-tile:hover .tml-lecture-tile__arrow {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.tml-lecture-tile__date {
   font-family: var(--font-mono);
   font-size: 0.75rem;
-  font-weight: 700;
-  flex-shrink: 0;
+  color: var(--tml-ink-muted);
+  margin: 0 0 4px;
 }
 
-.tml-recent-card__body {
-  flex: 1;
-  min-width: 0;
-}
-
-.tml-recent-card__title {
+.tml-lecture-tile__course {
   font-family: var(--font-body);
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: var(--tml-ink);
-  margin: 0 0 2px;
+  margin: 0 0 16px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.tml-recent-card__meta {
+.tml-lecture-tile__stats {
+  display: flex;
+  gap: 16px;
+  margin-top: auto;
+}
+
+.tml-lecture-tile__stat {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-family: var(--font-mono);
   font-size: 0.75rem;
   color: var(--tml-ink-muted);
-  margin: 0;
 }
 
-.tml-recent-card__arrow {
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  color: var(--tml-orange);
-  flex-shrink: 0;
+.tml-lecture-tile__stat-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
 }
 
 /* ── 활동 히트맵 ── */
@@ -1587,43 +1749,10 @@ body::after {
   padding: 0 2px;
 }
 
-/* ── 개념 클라우드 ── */
-@keyframes tml-tag-fade {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-.tml-concept-cloud {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-}
-
-.tml-concept-cloud__tag {
-  background: var(--tml-bg-overlay);
-  border: 1px solid var(--tml-rule);
-  border-radius: 6px;
-  padding: 6px 14px;
-  font-family: var(--font-body);
-  font-weight: 500;
-  color: var(--tml-ink-secondary);
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.15s;
-  animation: tml-tag-fade 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-.tml-concept-cloud__tag:hover {
-  background: var(--tml-orange-light);
-  border-color: var(--tml-orange);
-  color: var(--tml-orange-dark);
-  transform: translateY(-2px);
-}
-
 @media (prefers-reduced-motion: reduce) {
   .tml-heatmap__cell { animation: none; }
-  .tml-concept-cloud__tag { animation: none; }
   .tml-progress-ring__circle { transition: none; }
+  .tml-hero__bar-fill { transition: none; }
 }
 
 /* 주차 섹션 */

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,9 +5,8 @@ import { fetchWeeks, ApiError } from '../services/api'
 import { ErrorCard } from '../components/Skeleton'
 import { ProgressRing } from '../components/ProgressRing'
 import { ActivityHeatmap } from '../components/ActivityHeatmap'
-import { ConceptCloud } from '../components/ConceptCloud'
 
-// ── useCountUp 훅 ──
+/* ── useCountUp ── */
 
 function useCountUp(target: number, duration = 600) {
   const [value, setValue] = useState(0)
@@ -30,32 +29,27 @@ function useCountUp(target: number, duration = 600) {
   return value
 }
 
-// ── StatCard ──
+/* ── StatCard ── */
 
 interface StatCardProps {
   label: string
   value: number
-  icon: string
+  accent: string
   delay: number
 }
 
-function StatCard({ label, value, icon, delay }: StatCardProps) {
+function StatCard({ label, value, accent, delay }: StatCardProps) {
   const display = useCountUp(value)
   return (
-    <div
-      className="tml-stat-card tml-card tml-dashboard-stagger"
-      style={{ animationDelay: `${delay}ms` }}
-    >
-      <div className="tml-stat-card__header">
-        <span className="tml-stat-card__icon">{icon}</span>
-        <span className="tml-stat-card__label">{label}</span>
-      </div>
-      <span className="tml-stat-card__value">{display}</span>
+    <div className="tml-stat tml-dashboard-stagger" style={{ animationDelay: `${delay}ms` }}>
+      <div className="tml-stat__dot" style={{ background: accent }} />
+      <span className="tml-stat__label">{label}</span>
+      <span className="tml-stat__value">{display}</span>
     </div>
   )
 }
 
-// ── RecentLectureCard ──
+/* ── RecentLectureCard (vertical tile) ── */
 
 interface RecentLectureCardProps {
   lectureId: string
@@ -65,31 +59,40 @@ interface RecentLectureCardProps {
   courseName: string
   conceptCount: number
   quizCount: number
+  delay: number
 }
 
-function RecentLectureCard({ lectureId, date, dayOfWeek, week, courseName, conceptCount, quizCount }: RecentLectureCardProps) {
+function RecentLectureCard({
+  lectureId, date, dayOfWeek, week, courseName,
+  conceptCount, quizCount, delay,
+}: RecentLectureCardProps) {
   return (
     <Link
       to={`/lecture/${lectureId}`}
-      className="tml-card tml-recent-card"
+      className="tml-card tml-lecture-tile tml-dashboard-stagger"
+      style={{ animationDelay: `${delay}ms` }}
     >
-      <div className="tml-recent-card__badge">
-        W{week}
+      <div className="tml-lecture-tile__header">
+        <span className="tml-lecture-tile__week">W{week}</span>
+        <span className="tml-lecture-tile__arrow">→</span>
       </div>
-      <div className="tml-recent-card__body">
-        <p className="tml-recent-card__title">
-          {date} ({dayOfWeek}) · {courseName}
-        </p>
-        <p className="tml-recent-card__meta">
-          개념 {conceptCount}개 · 퀴즈 {quizCount}개
-        </p>
+      <p className="tml-lecture-tile__date">{date} ({dayOfWeek})</p>
+      <p className="tml-lecture-tile__course">{courseName}</p>
+      <div className="tml-lecture-tile__stats">
+        <span className="tml-lecture-tile__stat">
+          <span className="tml-lecture-tile__stat-dot" style={{ background: 'var(--tml-quiz-code)' }} />
+          개념 {conceptCount}
+        </span>
+        <span className="tml-lecture-tile__stat">
+          <span className="tml-lecture-tile__stat-dot" style={{ background: 'var(--tml-quiz-fill)' }} />
+          퀴즈 {quizCount}
+        </span>
       </div>
-      <span className="tml-recent-card__arrow">→</span>
     </Link>
   )
 }
 
-// ── Dashboard ──
+/* ── Dashboard ── */
 
 export function Dashboard() {
   const [weeks, setWeeks] = useState<WeekSummary[]>([])
@@ -120,156 +123,139 @@ export function Dashboard() {
 
   const allLectures = weeks.flatMap((w) => w.lectures)
   const remainingCount = totalLectures - completedLectures
+  const percent = totalLectures > 0 ? Math.round((completedLectures / totalLectures) * 100) : 0
 
-  // 최근 완료 강의 (최대 3개)
   const recentCompleted = allLectures
     .filter((l) => l.status === 'completed' && l.result_summary)
     .slice(0, 3)
 
-  // 다음 분석할 강의
   const nextLecture = allLectures.find((l) => l.status === 'idle')
 
   return (
     <main style={{ maxWidth: 1120, margin: '0 auto', padding: '40px 40px 80px' }}>
-
-      {/* 페이지 헤더 */}
-      <div className="tml-animate">
-        <p style={{
-          fontFamily: 'var(--font-body)',
-          fontSize: '0.6875rem',
-          fontWeight: 600,
-          color: 'var(--tml-orange)',
-          letterSpacing: '0.1em',
-          textTransform: 'uppercase',
-          margin: '0 0 8px',
-        }}>
-          Knowledge Dashboard
-        </p>
-        <h1 style={{
-          fontFamily: 'var(--font-display)',
-          fontWeight: 700,
-          fontSize: '1.75rem',
-          letterSpacing: '-0.02em',
-          color: 'var(--tml-ink)',
-          margin: '0 0 28px',
-        }}>
-          대시보드
-        </h1>
-      </div>
-
       {/* 로딩 */}
       {loading && (
-        <div style={{ display: 'flex', gap: 12, marginBottom: 32 }}>
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="tml-skeleton" style={{ height: 80, flex: 1, borderRadius: 6 }} />
-          ))}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div className="tml-skeleton" style={{ height: 220, borderRadius: 16 }} />
+          <div style={{ display: 'flex', gap: 12 }}>
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="tml-skeleton" style={{ height: 120, flex: 1, borderRadius: 12 }} />
+            ))}
+          </div>
         </div>
       )}
 
       {/* 에러 */}
-      {!loading && error && (
-        <ErrorCard message={error} title="데이터 로드 실패" />
-      )}
+      {!loading && error && <ErrorCard message={error} title="데이터 로드 실패" />}
 
       {/* 콘텐츠 */}
       {!loading && !error && (
         <>
-          {/* ── 히어로: 프로그레스 링 + 환영 메시지 ── */}
-          <div className="tml-dashboard-hero tml-animate">
-            <ProgressRing completed={completedLectures} total={totalLectures} />
-            <div className="tml-dashboard-hero__text">
-              <h2 className="tml-dashboard-hero__greeting">
-                학습 진행률
-              </h2>
-              <p className="tml-dashboard-hero__summary">
-                {totalLectures > 0 ? (
-                  <>
-                    전체 <strong>{totalLectures}개</strong> 강의 중{' '}
-                    <strong>{completedLectures}개</strong> 분석 완료
-                    {remainingCount > 0 && <>, <strong>{remainingCount}개</strong> 남음</>}
-                  </>
-                ) : (
-                  '등록된 강의가 없습니다.'
+          {/* ── 히어로 ── */}
+          <section className="tml-hero tml-animate">
+            <div className="tml-hero__decor" aria-hidden="true">
+              <div className="tml-hero__ring tml-hero__ring--1" />
+              <div className="tml-hero__ring tml-hero__ring--2" />
+              <div className="tml-hero__ring tml-hero__ring--3" />
+              <div className="tml-hero__glow" />
+            </div>
+
+            <div className="tml-hero__content">
+              <ProgressRing completed={completedLectures} total={totalLectures} />
+              <div className="tml-hero__info">
+                <p className="tml-hero__eyebrow">Learning Progress</p>
+                <h1 className="tml-hero__title">학습 진행률</h1>
+                <p className="tml-hero__desc">
+                  {totalLectures > 0 ? (
+                    <>
+                      전체 <strong>{totalLectures}개</strong> 강의 중{' '}
+                      <strong>{completedLectures}개</strong> 분석 완료
+                      {remainingCount > 0 && (
+                        <>, <strong>{remainingCount}개</strong> 남음</>
+                      )}
+                    </>
+                  ) : (
+                    '등록된 강의가 없습니다.'
+                  )}
+                </p>
+                {nextLecture && (
+                  <Link to="/lectures" className="tml-hero__cta">
+                    다음 강의 분석하기
+                    <span className="tml-hero__cta-arrow">→</span>
+                  </Link>
                 )}
-              </p>
-              {nextLecture && (
-                <Link
-                  to="/lectures"
-                  className="btn-primary"
-                  style={{ textDecoration: 'none', display: 'inline-block', marginTop: 12 }}
-                >
-                  다음 강의 분석하기 →
-                </Link>
-              )}
+              </div>
+            </div>
+
+            <div className="tml-hero__bar">
+              <div className="tml-hero__bar-fill" style={{ width: `${percent}%` }} />
+            </div>
+          </section>
+
+          {/* ── 벤토 그리드 ── */}
+          <div className="tml-bento tml-animate">
+            <StatCard label="전체 강의" value={totalLectures} accent="var(--tml-orange)" delay={0} />
+            <StatCard label="분석 완료" value={completedLectures} accent="var(--tml-navy-mid)" delay={80} />
+            <StatCard label="생성 퀴즈" value={totalQuizzes} accent="var(--tml-quiz-fill)" delay={160} />
+            <StatCard label="핵심 개념" value={totalConcepts} accent="var(--tml-quiz-code)" delay={240} />
+            <div
+              className="tml-bento__map tml-card tml-dashboard-stagger"
+              style={{ animationDelay: '120ms' }}
+            >
+              <p className="tml-bento__map-label">주간 활동</p>
+              <ActivityHeatmap lectures={allLectures} />
             </div>
           </div>
 
-          {/* ── 통계 카드 4개 ── */}
-          <div className="tml-dashboard-stats tml-animate">
-            <StatCard label="전체 강의" value={totalLectures} icon="📚" delay={0} />
-            <StatCard label="분석 완료" value={completedLectures} icon="✅" delay={100} />
-            <StatCard label="생성 퀴즈" value={totalQuizzes} icon="❓" delay={200} />
-            <StatCard label="핵심 개념" value={totalConcepts} icon="💡" delay={300} />
-          </div>
-
-          {/* ── 2컬럼: 최근 완료 + 히트맵 ── */}
-          <div className="tml-dashboard-grid tml-animate">
-            {/* 왼쪽: 최근 완료 강의 */}
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-                <p className="section-label" style={{ margin: 0, paddingTop: 0, borderTop: 'none' }}>최근 분석 완료</p>
-                <Link to="/lectures" style={{
+          {/* ── 최근 완료 강의 ── */}
+          <div className="tml-animate">
+            <div style={{
+              display: 'flex', justifyContent: 'space-between',
+              alignItems: 'center', marginBottom: 16,
+            }}>
+              <p className="section-label" style={{ margin: 0, paddingTop: 0, borderTop: 'none' }}>
+                최근 분석 완료
+              </p>
+              <Link
+                to="/lectures"
+                style={{
                   fontFamily: 'var(--font-body)', fontSize: '0.8125rem',
                   color: 'var(--tml-orange)', textDecoration: 'none', fontWeight: 600,
+                }}
+              >
+                전체 보기 →
+              </Link>
+            </div>
+            {recentCompleted.length > 0 ? (
+              <div className="tml-recent-grid">
+                {recentCompleted.map((l, i) => (
+                  <RecentLectureCard
+                    key={l.lecture_id}
+                    lectureId={l.lecture_id}
+                    date={l.date}
+                    dayOfWeek={l.day_of_week}
+                    week={l.week}
+                    courseName={l.course_name}
+                    conceptCount={l.result_summary!.concept_count}
+                    quizCount={l.result_summary!.quiz_count}
+                    delay={i * 80}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="tml-card" style={{ padding: '48px 24px', textAlign: 'center' }}>
+                <p style={{
+                  fontFamily: 'var(--font-body)', color: 'var(--tml-ink-muted)',
+                  margin: '0 0 16px', fontSize: '0.875rem',
                 }}>
-                  전체 보기 →
+                  아직 분석된 강의가 없습니다.
+                </p>
+                <Link to="/lectures" className="btn-primary" style={{ textDecoration: 'none' }}>
+                  강의 가져오기 →
                 </Link>
               </div>
-              {recentCompleted.length > 0 ? (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                  {recentCompleted.map((l) => (
-                    <RecentLectureCard
-                      key={l.lecture_id}
-                      lectureId={l.lecture_id}
-                      date={l.date}
-                      dayOfWeek={l.day_of_week}
-                      week={l.week}
-                      courseName={l.course_name}
-                      conceptCount={l.result_summary!.concept_count}
-                      quizCount={l.result_summary!.quiz_count}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div className="tml-card" style={{ padding: '32px 24px', textAlign: 'center' }}>
-                  <p style={{ fontFamily: 'var(--font-body)', color: 'var(--tml-ink-muted)', margin: '0 0 16px', fontSize: '0.875rem' }}>
-                    아직 분석된 강의가 없습니다.
-                  </p>
-                  <Link to="/lectures" className="btn-primary" style={{ textDecoration: 'none' }}>
-                    강의 가져오기 →
-                  </Link>
-                </div>
-              )}
-            </div>
-
-            {/* 오른쪽: 활동 히트맵 */}
-            <div>
-              <p className="section-label" style={{ margin: '0 0 16px', paddingTop: 0, borderTop: 'none' }}>주간 활동</p>
-              <div className="tml-card" style={{ padding: '20px' }}>
-                <ActivityHeatmap lectures={allLectures} />
-              </div>
-            </div>
+            )}
           </div>
-
-          {/* ── 개념 클라우드 ── */}
-          {allLectures.some((l) => l.status === 'completed') && (
-            <div className="tml-animate" style={{ marginTop: 36 }}>
-              <p className="section-label" style={{ margin: '0 0 16px' }}>최근 학습 키워드</p>
-              <div className="tml-card" style={{ padding: '24px' }}>
-                <ConceptCloud lectures={allLectures} />
-              </div>
-            </div>
-          )}
         </>
       )}
     </main>


### PR DESCRIPTION
## Summary
- 히어로 섹션을 다크 네이비 그라디언트 배경 + 장식 링 + 수평 프로그레스 바로 전면 리디자인
- 4개 스탯 카드 + 히트맵을 벤토 그리드(2×2 + 우측 히트맵) 레이아웃으로 재배치
- 스탯 카드에서 이모지 제거, 컬러 도트 인디케이터 + Syne 디스플레이 폰트 적용
- 최근 강의를 3열 세로 타일 카드로 변경 (오렌지 탑 보더, hover 화살표 애니메이션)
- "최근 학습 키워드" (ConceptCloud) 섹션 제거

## Test plan
- [ ] 라이트/다크 테마 전환 시 히어로 배경 및 텍스트 색상 정상 표시
- [ ] 벤토 그리드 반응형(768px 이하) 레이아웃 확인
- [ ] 프로그레스 링 애니메이션 + 수평 바 transition 동작
- [ ] 최근 강의 타일 hover 효과 (lift + 화살표 페이드인)
- [ ] 분석된 강의 없을 때 빈 상태 UI 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)