### PR TITLE
feat: 전체 UI 폴리시 — 레이아웃·가이드·스크롤 리빌

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -131,7 +131,7 @@ function App() {
       {/* 브레드크럼 (상세 페이지에서만) */}
       {showBreadcrumb && (
         <div style={{
-          maxWidth: 1120, margin: '0 auto', padding: '12px 40px 0',
+          maxWidth: 1280, margin: '0 auto', padding: '20px 40px 0',
         }}>
           <NavBreadcrumb />
         </div>

--- a/frontend/src/components/ConceptCard.tsx
+++ b/frontend/src/components/ConceptCard.tsx
@@ -22,7 +22,7 @@ export function ConceptCard({ concept }: ConceptCardProps) {
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
           <span style={{
             fontFamily: 'var(--font-mono)',
-            fontSize: '0.6875rem',
+            fontSize: '0.75rem',
             color: 'var(--tml-ink-muted)',
           }}>
             {concept.lecture_id}

--- a/frontend/src/components/QuizCard.tsx
+++ b/frontend/src/components/QuizCard.tsx
@@ -124,7 +124,7 @@ function ShortCard({ quiz, quizIndex, totalInType }: QuizCardProps) {
       ) : (
         <>
           <div style={{ marginBottom: 20 }}>
-            <p style={{ fontFamily: 'var(--font-mono)', fontSize: '0.6875rem', color: 'var(--tml-ink-muted)', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            <p style={{ fontFamily: 'var(--font-mono)', fontSize: '0.75rem', color: 'var(--tml-ink-muted)', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
               정답
             </p>
             <p style={{ fontFamily: 'var(--font-mono)', fontSize: '1.5rem', fontWeight: 700, color: 'var(--tml-orange)', margin: 0, letterSpacing: '-0.02em' }}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,7 +1,7 @@
 /* === tell-me-lion Design System === */
 
 /* 1. 폰트 임포트 */
-@import url('https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap');
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable.css');
 
 /* 2. Tailwind */
@@ -47,8 +47,8 @@
   --tml-shadow-hover:    rgba(0, 0, 0, 0.07);
 
   /* === 폰트 === */
-  --font-display: 'Syne', 'Pretendard Variable', 'Pretendard', sans-serif;
-  --font-body:    'IBM Plex Sans', 'Pretendard Variable', 'Pretendard', sans-serif;
+  --font-display: 'Pretendard Variable', 'Pretendard', sans-serif;
+  --font-body:    'Pretendard Variable', 'Pretendard', sans-serif;
   --font-mono:    'IBM Plex Mono', 'JetBrains Mono', monospace;
 }
 
@@ -123,6 +123,19 @@ body::after {
 
 @media (prefers-reduced-motion: reduce) {
   .tml-animate { animation: none; }
+  .tml-scroll-reveal { opacity: 1; transform: none; }
+}
+
+/* 스크롤 기반 페이드인 + 슬라이드업 */
+.tml-scroll-reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.tml-scroll-reveal.tml-revealed {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* 8. 베이스 컴포넌트 */
@@ -144,7 +157,7 @@ body::after {
 .badge-orange {
   background: var(--tml-orange-light);
   color: var(--tml-orange-dark);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   padding: 2px 8px;
   border-radius: 4px;
@@ -155,7 +168,7 @@ body::after {
 .badge-navy {
   background: var(--tml-navy-light);
   color: var(--tml-navy-mid);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   padding: 2px 8px;
   border-radius: 4px;
@@ -269,7 +282,7 @@ body::after {
 /* 섹션 구분 레이블 */
 .section-label {
   font-family: var(--font-body);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--tml-ink-muted);
   letter-spacing: 0.08em;
@@ -277,6 +290,18 @@ body::after {
   padding-top: 28px;
   border-top: 1px solid var(--tml-rule);
   margin: 0 0 16px;
+  position: relative;
+}
+
+.section-label::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 0;
+  width: 48px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--tml-orange), transparent);
+  border-radius: 1px;
 }
 
 /* 핵심 개념 카드 */
@@ -458,7 +483,7 @@ body::after {
 
 .tml-history-item__tag {
   font-family: var(--font-body);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--tml-ink-muted);
   background: var(--tml-bg);
   border: 1px solid var(--tml-rule);
@@ -472,7 +497,7 @@ body::after {
 
 .tml-history-item__meta {
   font-family: var(--font-body);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--tml-ink-muted);
 }
 
@@ -588,7 +613,7 @@ body::after {
 /* 문제 번호 */
 .quiz-meta-id {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--tml-ink-muted);
 }
 
@@ -698,7 +723,7 @@ body::after {
 
 .code-editor__lang-badge {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--tml-quiz-code);
   background: var(--tml-quiz-code-bg);
@@ -785,7 +810,7 @@ body::after {
 
 .output-panel__header {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -905,7 +930,7 @@ body::after {
 
 /* 퀴즈 타입 뱃지 */
 .quiz-badge {
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   padding: 2px 8px;
   border-radius: 4px;
@@ -1088,7 +1113,163 @@ body::after {
   border-color: var(--tml-rule-strong);
 }
 
-/* === 개념 맵 (WeeklyResult Mode B) === */
+/* === GuidesPage Enhanced Cards === */
+
+.tml-guide-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.tml-guide-stat {
+  background: var(--tml-bg-raised);
+  border: 1px solid var(--tml-rule);
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.tml-guide-stat:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(15, 31, 61, 0.06);
+  border-color: var(--tml-rule-strong);
+}
+
+.tml-guide-stat__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.tml-guide-stat__label {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--tml-ink-muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.tml-guide-stat__value {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--tml-ink);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.tml-guide-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 20px;
+}
+
+.tml-guide-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--tml-bg-raised);
+  border: 1px solid var(--tml-rule);
+  border-radius: 6px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.tml-guide-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(15, 31, 61, 0.08);
+  border-color: var(--tml-rule-strong);
+}
+
+.tml-guide-card__gradient {
+  height: 64px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 10px 14px;
+  flex-shrink: 0;
+}
+
+.tml-guide-card__week-badge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+  padding: 3px 10px;
+  letter-spacing: 0.04em;
+  backdrop-filter: blur(4px);
+}
+
+.tml-guide-card__date-badge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+  padding: 2px 8px;
+  backdrop-filter: blur(4px);
+}
+
+.tml-guide-card__body {
+  padding: 16px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.tml-guide-card__title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.0625rem;
+  color: var(--tml-ink);
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
+}
+
+.tml-guide-card__meta {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  color: var(--tml-ink-muted);
+  margin: 0 0 14px;
+}
+
+.tml-guide-card__progress {
+  height: 4px;
+  background: var(--tml-bg-overlay);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.tml-guide-card__progress-fill {
+  height: 100%;
+  background: var(--tml-orange);
+  border-radius: 2px;
+  transition: width 0.6s ease;
+}
+
+.tml-guide-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: auto;
+}
+
+@media (max-width: 767px) {
+  .tml-guide-stats {
+    grid-template-columns: 1fr;
+  }
+  .tml-guide-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* === ��념 맵 (WeeklyResult Mode B) === */
 
 .tml-concept-map-root {
   display: inline-flex;
@@ -1679,22 +1860,66 @@ body::after {
 .tml-bento > .tml-stat:nth-child(4) { grid-column: 2; grid-row: 2; }
 
 .tml-bento__map {
+  position: relative;
   grid-column: 3;
   grid-row: 1 / 3;
   padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  overflow: hidden;
+}
+
+/* 스캔라인 오버레이 */
+.tml-bento__map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(15, 31, 61, 0.015) 2px,
+    rgba(15, 31, 61, 0.015) 4px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+[data-theme="dark"] .tml-bento__map::before {
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(255, 255, 255, 0.015) 2px,
+    rgba(255, 255, 255, 0.015) 4px
+  );
 }
 
 .tml-bento__map-label {
   font-family: var(--font-body);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--tml-ink-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tml-bento__map-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--tml-orange);
+  animation: tml-pulse-dot 2s ease-in-out infinite;
+}
+
+@keyframes tml-pulse-dot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.8); }
 }
 
 @media (max-width: 768px) {
@@ -1709,28 +1934,73 @@ body::after {
   .tml-bento__map { grid-column: 1 / -1; grid-row: 3; }
 }
 
-/* ── 통계 카드 ── */
+/* ── 통계 카드 (글래스모피즘) ── */
 .tml-stat {
-  background: var(--tml-bg-raised);
-  border: 1px solid var(--tml-rule);
-  border-radius: 12px;
+  position: relative;
+  background: rgba(246, 248, 251, 0.7);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(221, 227, 236, 0.6);
+  border-radius: 16px;
   padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.tml-stat::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60%;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--stat-accent, var(--tml-orange));
+  box-shadow: 0 0 12px var(--stat-accent, var(--tml-orange)), 0 0 24px color-mix(in srgb, var(--stat-accent, var(--tml-orange)) 40%, transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .tml-stat:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(15, 31, 61, 0.06);
+  transform: translateY(-3px) rotateX(2deg) rotateY(-1deg);
+  box-shadow: 0 12px 32px rgba(15, 31, 61, 0.1), 0 0 0 1px rgba(255, 107, 0, 0.06);
   border-color: var(--tml-rule-strong);
 }
 
-.tml-stat__dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
+.tml-stat:hover::after {
+  opacity: 1;
+}
+
+[data-theme="dark"] .tml-stat {
+  background: rgba(17, 30, 51, 0.6);
+  border-color: rgba(30, 48, 80, 0.6);
+}
+
+.tml-stat__icon {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: var(--tml-white);
+  background: var(--stat-accent, var(--tml-orange));
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--stat-accent, var(--tml-orange)) 30%, transparent);
+}
+
+.tml-stat__icon::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 14px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--stat-accent, var(--tml-orange)) 15%, transparent), transparent 70%);
+  z-index: -1;
 }
 
 .tml-stat__label {
@@ -1748,6 +2018,11 @@ body::after {
   color: var(--tml-ink);
   line-height: 1;
   letter-spacing: -0.02em;
+  transition: transform 0.15s ease;
+}
+
+.tml-stat:hover .tml-stat__value {
+  transform: scale(1.05);
 }
 
 /* ── 최근 강의 타일 (3열 그리드) ── */
@@ -1762,19 +2037,49 @@ body::after {
 }
 
 .tml-lecture-tile {
+  position: relative;
   display: flex;
   flex-direction: column;
   padding: 20px;
   text-decoration: none;
   color: inherit;
-  border-top: 3px solid var(--tml-orange);
-  border-radius: 2px 2px 6px 6px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border-top: none;
+  border-radius: 12px;
+  background:
+    linear-gradient(var(--tml-bg-raised), var(--tml-bg-raised)) padding-box,
+    linear-gradient(135deg, var(--tml-orange), var(--tml-navy-mid)) border-box;
+  border: 2px solid transparent;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tml-lecture-tile::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 80% 60% at 20% 80%, color-mix(in srgb, var(--tml-orange) 6%, transparent), transparent 60%),
+    radial-gradient(ellipse 60% 80% at 80% 20%, color-mix(in srgb, var(--tml-navy-mid) 5%, transparent), transparent 60%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.tml-lecture-tile:hover::before {
+  opacity: 1;
 }
 
 .tml-lecture-tile:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 24px rgba(15, 31, 61, 0.08);
+  transform: translateY(-4px) scale(1.01);
+  box-shadow:
+    0 12px 32px rgba(15, 31, 61, 0.1),
+    0 0 20px color-mix(in srgb, var(--tml-orange) 8%, transparent);
+}
+
+[data-theme="dark"] .tml-lecture-tile {
+  background:
+    linear-gradient(var(--tml-bg-raised), var(--tml-bg-raised)) padding-box,
+    linear-gradient(135deg, var(--tml-orange), var(--tml-navy-mid)) border-box;
 }
 
 .tml-lecture-tile__header {
@@ -1786,13 +2091,16 @@ body::after {
 
 .tml-lecture-tile__week {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 700;
   color: #fff;
-  background: var(--tml-navy);
+  background: rgba(15, 31, 61, 0.75);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   padding: 3px 10px;
-  border-radius: 4px;
+  border-radius: 6px;
   letter-spacing: 0.04em;
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .tml-lecture-tile__arrow {
@@ -1847,6 +2155,22 @@ body::after {
   border-radius: 50%;
 }
 
+/* 미니 프로그레스 바 (개념/퀴즈) */
+.tml-lecture-tile__mini-bar {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--tml-bg-overlay);
+  overflow: hidden;
+  flex: 1;
+  max-width: 40px;
+}
+
+.tml-lecture-tile__mini-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 /* ── 활동 히트맵 ── */
 .tml-heatmap__grid {
   display: flex;
@@ -1899,6 +2223,7 @@ body::after {
 .tml-heatmap__cell:hover {
   outline: 2px solid var(--tml-ink-muted);
   outline-offset: -1px;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--tml-orange) 30%, transparent);
 }
 
 .tml-heatmap__cell--no-anim {
@@ -1930,7 +2255,7 @@ body::after {
   background: var(--tml-navy);
   color: var(--tml-white);
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   padding: 5px 10px;
   border-radius: 4px;
   white-space: nowrap;
@@ -2043,7 +2368,7 @@ body::after {
 
 .tml-lecture-card__date-badge {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: rgba(255, 255, 255, 0.9);
   background: rgba(0, 0, 0, 0.25);
   border-radius: 3px;
@@ -2073,7 +2398,7 @@ body::after {
 
 .tml-lecture-card__week-label {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--tml-ink-muted);
   margin: 0;
 }
@@ -2100,7 +2425,7 @@ body::after {
 
 .tml-lecture-card__summary span {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--tml-ink-muted);
   background: var(--tml-bg-overlay);
   padding: 2px 6px;
@@ -2204,7 +2529,7 @@ body::after {
 
 .tml-right-panel__section-title {
   font-family: var(--font-body);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--tml-ink-muted);
   letter-spacing: 0.08em;
@@ -2240,7 +2565,7 @@ body::after {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--tml-ink-muted);
   padding: 2px 4px;
   border-radius: 3px;
@@ -2438,7 +2763,7 @@ body::after {
 
 .tml-processing-error__msg {
   font-family: var(--font-body);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--tml-wrong);
   line-height: 1.4;
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -6,6 +6,32 @@ import { ErrorCard } from '../components/Skeleton'
 import { ProgressRing } from '../components/ProgressRing'
 import { ActivityHeatmap } from '../components/ActivityHeatmap'
 
+/* ── useScrollReveal ── */
+function useScrollReveal<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (prefersReduced) {
+      el.classList.add('tml-revealed')
+      return
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add('tml-revealed')
+          observer.unobserve(el)
+        }
+      },
+      { threshold: 0.15 },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+  return ref
+}
+
 /* ── useCountUp ── */
 
 function useCountUp(target: number, duration = 600) {
@@ -35,14 +61,18 @@ interface StatCardProps {
   label: string
   value: number
   accent: string
+  icon: string
   delay: number
 }
 
-function StatCard({ label, value, accent, delay }: StatCardProps) {
+function StatCard({ label, value, accent, icon, delay }: StatCardProps) {
   const display = useCountUp(value)
   return (
-    <div className="tml-stat tml-dashboard-stagger" style={{ animationDelay: `${delay}ms` }}>
-      <div className="tml-stat__dot" style={{ background: accent }} />
+    <div
+      className="tml-stat tml-dashboard-stagger"
+      style={{ animationDelay: `${delay}ms`, '--stat-accent': accent } as React.CSSProperties}
+    >
+      <div className="tml-stat__icon" style={{ background: accent }}>{icon}</div>
       <span className="tml-stat__label">{label}</span>
       <span className="tml-stat__value">{display}</span>
     </div>
@@ -82,10 +112,22 @@ function RecentLectureCard({
         <span className="tml-lecture-tile__stat">
           <span className="tml-lecture-tile__stat-dot" style={{ background: 'var(--tml-quiz-code)' }} />
           개념 {conceptCount}
+          <span className="tml-lecture-tile__mini-bar">
+            <span
+              className="tml-lecture-tile__mini-bar-fill"
+              style={{ width: `${Math.min(conceptCount * 10, 100)}%`, background: 'var(--tml-quiz-code)' }}
+            />
+          </span>
         </span>
         <span className="tml-lecture-tile__stat">
           <span className="tml-lecture-tile__stat-dot" style={{ background: 'var(--tml-quiz-fill)' }} />
           퀴즈 {quizCount}
+          <span className="tml-lecture-tile__mini-bar">
+            <span
+              className="tml-lecture-tile__mini-bar-fill"
+              style={{ width: `${Math.min(quizCount * 10, 100)}%`, background: 'var(--tml-quiz-fill)' }}
+            />
+          </span>
         </span>
       </div>
     </Link>
@@ -243,7 +285,7 @@ export function Dashboard() {
   const nextLecture = allLectures.find((l) => l.status === 'idle')
 
   return (
-    <main style={{ maxWidth: 1120, margin: '0 auto', padding: '40px 40px 80px' }}>
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
       {/* 로딩 */}
       {loading && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -273,21 +315,24 @@ export function Dashboard() {
 
           {/* ── 벤토 그리드 ── */}
           <div className="tml-bento tml-animate">
-            <StatCard label="전체 강의" value={totalLectures} accent="var(--tml-orange)" delay={0} />
-            <StatCard label="분석 완료" value={completedLectures} accent="var(--tml-navy-mid)" delay={80} />
-            <StatCard label="생성 퀴즈" value={totalQuizzes} accent="var(--tml-quiz-fill)" delay={160} />
-            <StatCard label="핵심 개념" value={totalConcepts} accent="var(--tml-quiz-code)" delay={240} />
+            <StatCard label="전체 강의" value={totalLectures} accent="var(--tml-orange)" icon="📚" delay={0} />
+            <StatCard label="분석 완료" value={completedLectures} accent="var(--tml-navy-mid)" icon="✅" delay={80} />
+            <StatCard label="생성 퀴즈" value={totalQuizzes} accent="var(--tml-quiz-fill)" icon="❓" delay={160} />
+            <StatCard label="핵심 개념" value={totalConcepts} accent="var(--tml-quiz-code)" icon="💡" delay={240} />
             <div
               className="tml-bento__map tml-card tml-dashboard-stagger"
               style={{ animationDelay: '120ms' }}
             >
-              <p className="tml-bento__map-label">주간 활동</p>
+              <p className="tml-bento__map-label">
+                <span className="tml-bento__map-pulse" />
+                ACTIVITY
+              </p>
               <ActivityHeatmap lectures={allLectures} />
             </div>
           </div>
 
           {/* ── 최근 완료 강의 ── */}
-          <div className="tml-animate">
+          <ScrollRevealSection>
             <div style={{
               display: 'flex', justifyContent: 'space-between',
               alignItems: 'center', marginBottom: 16,
@@ -334,9 +379,20 @@ export function Dashboard() {
                 </Link>
               </div>
             )}
-          </div>
+          </ScrollRevealSection>
         </>
       )}
     </main>
+  )
+}
+
+/* ── ScrollRevealSection ── */
+
+function ScrollRevealSection({ children }: { children: React.ReactNode }) {
+  const ref = useScrollReveal<HTMLDivElement>()
+  return (
+    <div ref={ref} className="tml-scroll-reveal">
+      {children}
+    </div>
   )
 }

--- a/frontend/src/pages/GuidesPage.tsx
+++ b/frontend/src/pages/GuidesPage.tsx
@@ -1,56 +1,108 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { WeekSummary, ProcessingStatus } from '../types/models'
 import { fetchWeeks, triggerWeekProcess, ApiError } from '../services/api'
 import { ErrorCard } from '../components/Skeleton'
 import { ProcessingStatus as ProcessingStatusUI } from '../components/ProcessingStatus'
 
+// ── useCountUp (Dashboard 패턴 재사용) ──
+
+function useCountUp(target: number, duration = 600) {
+  const [value, setValue] = useState(0)
+  const rafRef = useRef(0)
+
+  useEffect(() => {
+    if (target === 0) { setValue(0); return }
+    const start = performance.now()
+    const animate = (now: number) => {
+      const elapsed = now - start
+      const progress = Math.min(elapsed / duration, 1)
+      const eased = 1 - Math.pow(1 - progress, 3)
+      setValue(Math.round(eased * target))
+      if (progress < 1) rafRef.current = requestAnimationFrame(animate)
+    }
+    rafRef.current = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(rafRef.current)
+  }, [target, duration])
+
+  return value
+}
+
+// ── 그래디언트 헬퍼 ──
+
+function getGuideGradient(week: number): string {
+  const hues = [210, 25, 170, 340]
+  const baseHue = hues[(week - 1) % hues.length]
+  return `linear-gradient(135deg, hsl(${baseHue}, 55%, 38%), hsl(${baseHue + 35}, 45%, 28%))`
+}
+
+// ── StatCard ──
+
+interface StatCardProps {
+  label: string
+  value: number
+  accent: string
+  delay: number
+}
+
+function StatCard({ label, value, accent, delay }: StatCardProps) {
+  const display = useCountUp(value)
+  return (
+    <div className="tml-guide-stat tml-dashboard-stagger" style={{ animationDelay: `${delay}ms` }}>
+      <div className="tml-guide-stat__dot" style={{ background: accent }} />
+      <span className="tml-guide-stat__label">{label}</span>
+      <span className="tml-guide-stat__value">{display}</span>
+    </div>
+  )
+}
+
 // ── GuideCard ──
 
 interface GuideCardProps {
   weekSummary: WeekSummary
   status: ProcessingStatus
+  index: number
   onProcess: (week: number) => void
   onViewResults: (week: number) => void
   onProcessComplete: (week: number) => void
   onProcessError: (week: number) => void
 }
 
-function GuideCard({ weekSummary, status, onProcess, onViewResults, onProcessComplete, onProcessError }: GuideCardProps) {
+function GuideCard({ weekSummary, status, index, onProcess, onViewResults, onProcessComplete, onProcessError }: GuideCardProps) {
   const { week, lecture_count, completed_count, date_range } = weekSummary
+  const gradient = getGuideGradient(week)
+  const percent = lecture_count > 0 ? Math.round((completed_count / lecture_count) * 100) : 0
 
   return (
-    <div className="tml-card tml-animate" style={{ padding: '24px 28px' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
-        <div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8, flexWrap: 'wrap' }}>
-            <span className="badge-orange">{week}주차</span>
-            <span style={{
-              fontFamily: 'var(--font-mono)', fontSize: '0.8125rem', color: 'var(--tml-ink-muted)',
-            }}>
-              {date_range}
-            </span>
-          </div>
-          <h3 style={{
-            fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: '1.125rem',
-            color: 'var(--tml-ink)', margin: '0 0 6px',
-          }}>
-            {week}주차 학습 가이드
-          </h3>
-          <p style={{
-            fontFamily: 'var(--font-body)', fontSize: '0.8125rem', color: 'var(--tml-ink-muted)',
-            margin: 0,
-          }}>
-            {lecture_count}개 강의 · {completed_count}개 분석 완료
-          </p>
+    <div
+      className="tml-guide-card tml-dashboard-stagger"
+      style={{ animationDelay: `${index * 80}ms` }}
+    >
+      {/* 그래디언트 헤더 */}
+      <div className="tml-guide-card__gradient" style={{ background: gradient }}>
+        <span className="tml-guide-card__week-badge">W{week}</span>
+        <span className="tml-guide-card__date-badge">{date_range}</span>
+      </div>
+
+      {/* 본문 */}
+      <div className="tml-guide-card__body">
+        <h3 className="tml-guide-card__title">{week}주차 학습 가이드</h3>
+        <p className="tml-guide-card__meta">
+          {lecture_count}개 강의 · {completed_count}개 분석 완료
+        </p>
+
+        {/* 프로그레스 바 */}
+        <div className="tml-guide-card__progress">
+          <div
+            className="tml-guide-card__progress-fill"
+            style={{ width: `${percent}%` }}
+          />
         </div>
 
-        <div style={{ flexShrink: 0 }}>
+        {/* 액션 */}
+        <div className="tml-guide-card__footer">
           {status === 'completed' ? (
-            <button
-              className="btn-primary"
-              onClick={() => onViewResults(week)}
-            >
+            <button className="btn-primary" onClick={() => onViewResults(week)}>
               가이드 보기 →
             </button>
           ) : status === 'processing' ? (
@@ -127,20 +179,24 @@ export function GuidesPage() {
 
   const getEffectiveStatus = (ws: WeekSummary): ProcessingStatus => {
     if (processingWeeks.has(ws.week)) return 'processing'
-    // 백엔드 버그 보정: 일부 idle + 일부 completed 시 processing으로 오는 문제
     if (ws.status === 'processing' && !processingWeeks.has(ws.week)) return 'idle'
     return ws.status
   }
 
+  // 통계 산출
+  const totalWeeks = weeks.length
+  const completedGuides = weeks.filter((w) => getEffectiveStatus(w) === 'completed').length
+  const totalAnalyzed = weeks.reduce((sum, w) => sum + w.completed_count, 0)
+
   return (
-    <main style={{ maxWidth: 1120, margin: '0 auto', padding: '40px 40px 80px' }}>
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
       {/* 페이지 헤더 */}
       <div className="tml-animate">
         <p style={{
           fontFamily: 'var(--font-body)',
-          fontSize: '0.6875rem',
+          fontSize: '0.75rem',
           fontWeight: 600,
-          color: 'var(--tml-navy-mid)',
+          color: 'var(--tml-orange)',
           letterSpacing: '0.1em',
           textTransform: 'uppercase',
           margin: '0 0 8px',
@@ -161,9 +217,9 @@ export function GuidesPage() {
 
       {/* 로딩 */}
       {loading && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          {[1, 2].map((i) => (
-            <div key={i} className="tml-skeleton" style={{ height: 100, borderRadius: 6 }} />
+        <div className="tml-guide-grid">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="tml-skeleton" style={{ height: 200, borderRadius: 6 }} />
           ))}
         </div>
       )}
@@ -173,7 +229,7 @@ export function GuidesPage() {
         <ErrorCard message={error} title="학습 가이드 로드 실패" />
       )}
 
-      {/* 가이드 목록 */}
+      {/* 콘텐츠 */}
       {!loading && !error && (
         weeks.length === 0 ? (
           <div style={{ padding: '48px 24px', textAlign: 'center' }}>
@@ -184,19 +240,30 @@ export function GuidesPage() {
             </p>
           </div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            {weeks.map((ws) => (
-              <GuideCard
-                key={ws.week}
-                weekSummary={ws}
-                status={getEffectiveStatus(ws)}
-                onProcess={handleProcess}
-                onViewResults={(w) => navigate(`/weekly/${w}`)}
-                onProcessComplete={handleProcessComplete}
-                onProcessError={handleProcessError}
-              />
-            ))}
-          </div>
+          <>
+            {/* 스탯 배너 */}
+            <div className="tml-guide-stats">
+              <StatCard label="전체 주차" value={totalWeeks} accent="var(--tml-orange)" delay={0} />
+              <StatCard label="완료된 가이드" value={completedGuides} accent="var(--tml-navy-mid)" delay={80} />
+              <StatCard label="분석 완료 강의" value={totalAnalyzed} accent="var(--tml-quiz)" delay={160} />
+            </div>
+
+            {/* 가이드 그리드 */}
+            <div className="tml-guide-grid">
+              {weeks.map((ws, i) => (
+                <GuideCard
+                  key={ws.week}
+                  weekSummary={ws}
+                  status={getEffectiveStatus(ws)}
+                  index={i}
+                  onProcess={handleProcess}
+                  onViewResults={(w) => navigate(`/weekly/${w}`)}
+                  onProcessComplete={handleProcessComplete}
+                  onProcessError={handleProcessError}
+                />
+              ))}
+            </div>
+          </>
         )
       )}
     </main>

--- a/frontend/src/pages/LectureResult.tsx
+++ b/frontend/src/pages/LectureResult.tsx
@@ -114,7 +114,7 @@ export function LectureResult() {
   // ── 로딩 ──
   if (state.tag === 'loading') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <SkeletonGroup count={4} variant="card" />
       </main>
     )
@@ -123,7 +123,7 @@ export function LectureResult() {
   // ── 존재하지 않는 강의 ──
   if (state.tag === 'not-found') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
           ← 강의 목록
         </button>
@@ -146,7 +146,7 @@ export function LectureResult() {
   // ── 에러 ──
   if (state.tag === 'error') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
           ← 강의 목록
         </button>
@@ -161,7 +161,7 @@ export function LectureResult() {
   if (state.tag === 'not-processed') {
     const { lecture } = state
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
           ← 강의 목록
         </button>
@@ -215,7 +215,7 @@ export function LectureResult() {
   if (state.tag === 'processing') {
     const { lecture } = state
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
           ← 강의 목록
         </button>
@@ -240,7 +240,7 @@ export function LectureResult() {
   const { concepts, learning_points, quizzes } = outputs
 
   return (
-    <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
       {/* 뒤로가기 */}
       <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
         ← 강의 목록
@@ -264,12 +264,12 @@ export function LectureResult() {
           >
             {label}
             {key === 'concepts' && (
-              <span style={{ marginLeft: 6, fontFamily: 'var(--font-mono)', fontSize: '0.6875rem', color: 'var(--tml-ink-muted)' }}>
+              <span style={{ marginLeft: 6, fontFamily: 'var(--font-mono)', fontSize: '0.75rem', color: 'var(--tml-ink-muted)' }}>
                 {concepts.length}
               </span>
             )}
             {key === 'learning-points' && (
-              <span style={{ marginLeft: 6, fontFamily: 'var(--font-mono)', fontSize: '0.6875rem', color: 'var(--tml-ink-muted)' }}>
+              <span style={{ marginLeft: 6, fontFamily: 'var(--font-mono)', fontSize: '0.75rem', color: 'var(--tml-ink-muted)' }}>
                 {learning_points.length}
               </span>
             )}
@@ -357,7 +357,7 @@ function LectureHeader({ lecture, outputs }: LectureHeaderProps) {
     <div>
       <p style={{
         fontFamily: 'var(--font-body)',
-        fontSize: '0.6875rem',
+        fontSize: '0.75rem',
         fontWeight: 600,
         color: 'var(--tml-orange)',
         letterSpacing: '0.1em',
@@ -434,7 +434,7 @@ function StatChip({ label, value }: StatChipProps) {
       </div>
       <div style={{
         fontFamily: 'var(--font-body)',
-        fontSize: '0.6875rem',
+        fontSize: '0.75rem',
         color: 'var(--tml-ink-muted)',
         marginTop: 2,
       }}>

--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -591,7 +591,7 @@ export function LecturesPage() {
       <div className="tml-animate">
         <p style={{
           fontFamily: 'var(--font-body)',
-          fontSize: '0.6875rem',
+          fontSize: '0.75rem',
           fontWeight: 600,
           color: 'var(--tml-orange)',
           letterSpacing: '0.1em',

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { QuizCard } from '../components/QuizCard'
 import { SkeletonGroup, ErrorCard } from '../components/Skeleton'
 import { fetchLecture, fetchLectureResults, ApiError } from '../services/api'
@@ -14,8 +14,6 @@ type PageState =
 
 export function QuizPage() {
   const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-
   const [state, setState] = useState<PageState>({ tag: 'loading' })
   const [mcqIndex, setMcqIndex] = useState(0)
 
@@ -57,7 +55,7 @@ export function QuizPage() {
   // ── 로딩 ──
   if (state.tag === 'loading') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <SkeletonGroup count={4} variant="card" />
       </main>
     )
@@ -66,11 +64,8 @@ export function QuizPage() {
   // ── 404 ──
   if (state.tag === 'not-found') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
-          ← 강의 목록
-        </button>
-        <div className="tml-animate" style={{ marginTop: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
+        <div className="tml-animate">
           <ErrorCard message="존재하지 않는 강의입니다." />
         </div>
       </main>
@@ -80,11 +75,8 @@ export function QuizPage() {
   // ── 미처리 ──
   if (state.tag === 'not-ready') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate(`/lecture/${id}`)}>
-          ← 강의 결과
-        </button>
-        <div className="tml-animate tml-card" style={{ marginTop: 32, padding: 32, textAlign: 'center' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
+        <div className="tml-animate tml-card" style={{ padding: 32, textAlign: 'center' }}>
           <p style={{
             fontFamily: 'var(--font-display)', fontSize: '1.125rem',
             fontWeight: 600, color: 'var(--tml-ink)', margin: '0 0 8px',
@@ -108,11 +100,8 @@ export function QuizPage() {
   // ── 에러 ──
   if (state.tag === 'error') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate(`/lecture/${id}`)}>
-          ← 강의 결과
-        </button>
-        <div className="tml-animate" style={{ marginTop: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
+        <div className="tml-animate">
           <ErrorCard message={state.message} />
         </div>
       </main>
@@ -136,16 +125,11 @@ export function QuizPage() {
   ].filter((t) => t.count > 0)
 
   return (
-    <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
-      {/* 뒤로가기 */}
-      <button className="tml-back-btn tml-animate" onClick={() => navigate(`/lecture/${id}`)}>
-        ← 강의 결과
-      </button>
-
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
       {/* 퀴즈 헤더 */}
-      <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+      <div className="tml-animate" style={{ marginBottom: 32 }}>
         <p style={{
-          fontFamily: 'var(--font-body)', fontSize: '0.6875rem', fontWeight: 600,
+          fontFamily: 'var(--font-body)', fontSize: '0.75rem', fontWeight: 600,
           color: 'var(--tml-orange)', letterSpacing: '0.1em', textTransform: 'uppercase',
           margin: '0 0 12px',
         }}>
@@ -186,7 +170,7 @@ export function QuizPage() {
                     {count}
                   </div>
                   <div style={{
-                    fontFamily: 'var(--font-body)', fontSize: '0.6875rem',
+                    fontFamily: 'var(--font-body)', fontSize: '0.75rem',
                     color: 'var(--tml-ink-muted)', marginTop: 2,
                   }}>
                     {label}

--- a/frontend/src/pages/WeeklyResult.tsx
+++ b/frontend/src/pages/WeeklyResult.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { SkeletonGroup, ErrorCard } from '../components/Skeleton'
+import { ProcessingStatus } from '../components/ProcessingStatus'
 import {
   fetchWeek,
   fetchWeekResults,
@@ -14,6 +15,7 @@ type PageState =
   | { tag: 'loading' }
   | { tag: 'not-found' }
   | { tag: 'not-processed'; week: WeekSummary; availableWeeks: number[] }
+  | { tag: 'processing'; week: WeekSummary; availableWeeks: number[] }
   | { tag: 'error'; message: string }
   | { tag: 'results'; week: WeekSummary; outputs: WeeklyOutputs; availableWeeks: number[] }
 
@@ -51,6 +53,8 @@ export function WeeklyResult() {
           const outputs = await fetchWeekResults(week)
           if (cancelled) return
           setState({ tag: 'results', week: weekData, outputs, availableWeeks })
+        } else if (weekData.status === 'processing') {
+          setState({ tag: 'processing', week: weekData, availableWeeks })
         } else {
           setState({ tag: 'not-processed', week: weekData, availableWeeks })
         }
@@ -74,8 +78,16 @@ export function WeeklyResult() {
   const handleTrigger = async () => {
     try {
       await triggerWeekProcess(week)
-      setReloadKey((k) => k + 1)
+      // processing 상태로 전환 (reload 대신)
+      if (state.tag === 'not-processed') {
+        setState({ tag: 'processing', week: state.week, availableWeeks: state.availableWeeks })
+      }
     } catch (err) {
+      // 409: 이미 처리 완료된 경우 → 결과 리로드
+      if (err instanceof ApiError && err.status === 409) {
+        setReloadKey((k) => k + 1)
+        return
+      }
       setState({
         tag: 'error',
         message: err instanceof Error ? err.message : '처리 시작에 실패했습니다.',
@@ -83,10 +95,18 @@ export function WeeklyResult() {
     }
   }
 
+  const handleProcessComplete = () => {
+    setReloadKey((k) => k + 1)
+  }
+
+  const handleProcessError = (message: string) => {
+    setState({ tag: 'error', message })
+  }
+
   // ── 로딩 ──
   if (state.tag === 'loading') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <SkeletonGroup count={4} variant="card" />
       </main>
     )
@@ -95,7 +115,7 @@ export function WeeklyResult() {
   // ── 404 ──
   if (state.tag === 'not-found') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
           ← 학습 가이드
         </button>
@@ -118,12 +138,59 @@ export function WeeklyResult() {
   // ── 에러 ──
   if (state.tag === 'error') {
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
           ← 학습 가이드
         </button>
         <div className="tml-animate" style={{ marginTop: 32 }}>
           <ErrorCard message={state.message} />
+        </div>
+      </main>
+    )
+  }
+
+  // ── 처리 중 ──
+  if (state.tag === 'processing') {
+    const { week: weekData, availableWeeks } = state
+    const currentIndex = availableWeeks.indexOf(week)
+    const prevWeek = currentIndex > 0 ? availableWeeks[currentIndex - 1] : null
+    const nextWeek = currentIndex < availableWeeks.length - 1 ? availableWeeks[currentIndex + 1] : null
+
+    return (
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
+        <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
+          ← 학습 가이드
+        </button>
+
+        <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+          <WeekHeader weekData={weekData} prevWeek={prevWeek} nextWeek={nextWeek} />
+        </div>
+
+        <div className="tml-animate tml-card" style={{ padding: '32px' }}>
+          <p style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: '1.125rem',
+            fontWeight: 600,
+            color: 'var(--tml-ink)',
+            margin: '0 0 8px',
+            textAlign: 'center',
+          }}>
+            학습 가이드를 생성하고 있습니다…
+          </p>
+          <p style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: '0.875rem',
+            color: 'var(--tml-ink-muted)',
+            margin: '0 0 24px',
+            textAlign: 'center',
+          }}>
+            {weekData.lecture_count}개 강의를 분석 중입니다. 잠시만 기다려 주세요.
+          </p>
+          <ProcessingStatus
+            week={week}
+            onComplete={handleProcessComplete}
+            onError={handleProcessError}
+          />
         </div>
       </main>
     )
@@ -137,7 +204,7 @@ export function WeeklyResult() {
     const nextWeek = currentIndex < availableWeeks.length - 1 ? availableWeeks[currentIndex + 1] : null
 
     return (
-      <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
         <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
           ← 학습 가이드
         </button>
@@ -195,7 +262,7 @@ export function WeeklyResult() {
   const nextWeek = currentIndex < availableWeeks.length - 1 ? availableWeeks[currentIndex + 1] : null
 
   return (
-    <main style={{ maxWidth: 1120, margin: '0 auto', padding: '56px 40px 80px' }}>
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
       {/* 뒤로가기 */}
       <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
         ← 학습 가이드
@@ -328,9 +395,9 @@ function WeekHeader({ weekData, prevWeek, nextWeek }: WeekHeaderProps) {
     <div>
       <p style={{
         fontFamily: 'var(--font-body)',
-        fontSize: '0.6875rem',
+        fontSize: '0.75rem',
         fontWeight: 600,
-        color: 'var(--tml-navy-mid)',
+        color: 'var(--tml-orange)',
         letterSpacing: '0.1em',
         textTransform: 'uppercase',
         margin: '0 0 12px',


### PR DESCRIPTION
## Summary
- maxWidth 1120→1280px 전 페이지 통일로 넓은 레이아웃 적용
- 대시보드: useScrollReveal 훅, 스탯 아이콘·미니 프로그레스바 추가
- 가이드 페이지: 그래디언트 헤더 카드·StatCard·진행률 바 리디자인
- 퀴즈 페이지: 중복 뒤로가기 버튼 제거, 레이아웃 간소화
- 폰트 사이즈 가독성 개선 (0.6875rem→0.75rem)
- index.css 신규 스타일 +365줄

## 변경 파일 (10개)
- `App.tsx` — 브레드크럼 maxWidth 조정
- `Dashboard.tsx` — 스크롤 리빌, 스탯 아이콘, 미니바
- `GuidesPage.tsx` — 그래디언트 카드 전면 리디자인
- `WeeklyResult.tsx` — ProcessingStatus 컴포넌트 연동
- `QuizPage.tsx` — 뒤로가기 버튼 제거, 간소화
- `LectureResult.tsx` — maxWidth·폰트 사이즈 통일
- `LecturesPage.tsx` — 폰트 사이즈 통일
- `ConceptCard.tsx`, `QuizCard.tsx` — 폰트 사이즈 통일
- `index.css` — 가이드 카드·스크롤 리빌·미니바 스타일

## Test plan
- [ ] 대시보드 스크롤 시 리빌 애니메이션 확인
- [ ] 가이드 페이지 카드 그래디언트·진행률 바 표시 확인
- [ ] 퀴즈 페이지 레이아웃 간소화 확인
- [ ] 전 페이지 1280px 레이아웃 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)