### PR TITLE
fix: 주차 가이드 409 에러 처리 및 상태 UI 개선

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2272,7 +2272,7 @@ body::after {
 }
 
 .tml-heatmap__legend-label {
-  font-family: var(--font-mono);
+  font-family: 'Pretendard', sans-serif;
   font-size: 0.5625rem;
   color: var(--tml-ink-muted);
   padding: 0 2px;
@@ -2649,26 +2649,28 @@ body::after {
 .tml-processing-status {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 10px;
+  max-width: 360px;
+  margin: 0 auto;
 }
 
 .tml-processing-step {
   display: grid;
-  grid-template-columns: 16px 1fr auto;
+  grid-template-columns: 28px 1fr auto;
   align-items: center;
-  gap: 7px;
+  gap: 12px;
 }
 
 /* 단계 번호/체크 아이콘 */
 .tml-processing-step__icon {
-  width: 16px;
-  height: 16px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.5625rem;
-  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-family: 'Pretendard', sans-serif;
   font-weight: 600;
   flex-shrink: 0;
   transition: background 0.2s ease;
@@ -2699,10 +2701,10 @@ body::after {
 }
 
 .tml-processing-step__name {
-  font-family: var(--font-body);
-  font-size: 0.625rem;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 0.875rem;
   font-weight: 500;
-  line-height: 1;
+  line-height: 1.2;
 }
 
 .tml-processing-step--pending .tml-processing-step__name { color: var(--tml-ink-muted); }
@@ -2710,7 +2712,7 @@ body::after {
 .tml-processing-step--done   .tml-processing-step__name { color: var(--tml-ink-secondary); }
 
 .tml-processing-step__track {
-  height: 3px;
+  height: 4px;
   background: var(--tml-bg-overlay);
   border-radius: 2px;
   overflow: hidden;
@@ -2743,9 +2745,9 @@ body::after {
 
 /* 상태 라벨 */
 .tml-processing-step__label {
-  font-family: var(--font-mono);
-  font-size: 0.5rem;
-  letter-spacing: 0.04em;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
   flex-shrink: 0;
   line-height: 1;
 }

--- a/frontend/src/pages/GuidesPage.tsx
+++ b/frontend/src/pages/GuidesPage.tsx
@@ -148,14 +148,24 @@ export function GuidesPage() {
     setProcessingWeeks((prev) => new Set(prev).add(week))
     try {
       await triggerWeekProcess(week)
-    } catch {
+    } catch (err) {
+      // 409: 이미 처리 중이거나 완료 → 결과 페이지로 이동
+      if (err instanceof ApiError && err.status === 409) {
+        setProcessingWeeks((prev) => {
+          const next = new Set(prev)
+          next.delete(week)
+          return next
+        })
+        navigate(`/weekly/${week}`)
+        return
+      }
       setProcessingWeeks((prev) => {
         const next = new Set(prev)
         next.delete(week)
         return next
       })
     }
-  }, [])
+  }, [navigate])
 
   const handleProcessComplete = useCallback(
     (week: number) => {

--- a/frontend/src/pages/WeeklyResult.tsx
+++ b/frontend/src/pages/WeeklyResult.tsx
@@ -83,9 +83,17 @@ export function WeeklyResult() {
         setState({ tag: 'processing', week: state.week, availableWeeks: state.availableWeeks })
       }
     } catch (err) {
-      // 409: 이미 처리 완료된 경우 → 결과 리로드
       if (err instanceof ApiError && err.status === 409) {
-        setReloadKey((k) => k + 1)
+        // 409: 이미 처리 중이거나 완료 → force=true로 재시도
+        try {
+          await triggerWeekProcess(week, true)
+          if (state.tag === 'not-processed') {
+            setState({ tag: 'processing', week: state.week, availableWeeks: state.availableWeeks })
+          }
+        } catch {
+          // force도 실패 시 결과 리로드
+          setReloadKey((k) => k + 1)
+        }
         return
       }
       setState({


### PR DESCRIPTION
## Summary
- **GuidesPage**: `POST /api/weeks/{week}/process` 409 Conflict 시 결과 페이지(`/weekly/:week`)로 자동 이동
- **WeeklyResult**: 409 시 `force=true` 파라미터로 재처리 시도, 실패 시 결과 리로드 폴백
- 처리 상태 스텝 UI 크기·폰트 가독성 개선 (아이콘 28px, 폰트 0.875rem)

## Test plan
- [ ] `/weekly/2` 페이지에서 "지금 생성하기" 클릭 → 정상 처리 확인
- [ ] 이미 처리된 주차에서 재클릭 시 409 → 결과 페이지 이동 확인
- [ ] 처리 상태 스텝 UI가 가독성 있게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)