### PR TITLE
fix: 대시보드 라이트모드 배경색 수정

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1853,12 +1853,12 @@ body::after {
   margin-top: 4px;
 }
 
-/* ── 대시보드 다크 배경 ── */
+/* ── 대시보드 배경 ── */
 .tml-dashboard-bg {
   background:
-    radial-gradient(ellipse 80% 50% at 20% 80%, rgba(255, 85, 0, 0.04) 0%, transparent 60%),
-    radial-gradient(ellipse 60% 60% at 80% 20%, rgba(15, 31, 61, 0.08) 0%, transparent 50%),
-    linear-gradient(180deg, #0C1220 0%, #0F1828 40%, #0A1018 100%);
+    radial-gradient(ellipse 80% 50% at 20% 80%, rgba(255, 85, 0, 0.03) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 60% at 80% 20%, rgba(15, 31, 61, 0.04) 0%, transparent 50%),
+    linear-gradient(180deg, #F0F2F6 0%, #F6F8FB 40%, #FFFFFF 100%);
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- 대시보드 `.tml-dashboard-bg` 기본 배경이 다크 컬러로 하드코딩되어 라이트모드에서도 검정 배경이 나오던 버그 수정
- 라이트모드 기본 배경을 밝은 그라디언트(`#F0F2F6` → `#F6F8FB` → `#FFFFFF`)로 교체
- 다크모드(`[data-theme="dark"]`)는 기존 스타일 유지

## Test plan
- [ ] 라이트모드에서 대시보드 배경이 밝은 색으로 표시되는지 확인
- [ ] 다크모드에서 대시보드 배경이 기존과 동일한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)