### PR TITLE
fix: 대시보드 히어로 다크 전용 스타일 통일

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1475,16 +1475,17 @@ body::after {
 
 .tml-hero {
   position: relative;
-  background: #F4F0EC;
+  background: #060810;
   border-radius: 20px;
   padding: 48px 44px 24px;
   margin-bottom: 24px;
   overflow: hidden;
-  border: 1px solid rgba(255, 107, 0, 0.12);
+  border: 1px solid rgba(255, 107, 0, 0.1);
   box-shadow:
-    0 0 0 1px rgba(255, 107, 0, 0.04),
-    0 4px 24px rgba(0, 0, 0, 0.06),
-    0 16px 56px rgba(0, 0, 0, 0.04);
+    0 0 0 1px rgba(255, 107, 0, 0.06),
+    0 4px 32px rgba(0, 0, 0, 0.6),
+    0 20px 60px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.02);
   will-change: transform;
 }
 
@@ -1493,10 +1494,10 @@ body::after {
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse 80% 60% at 10% 90%, rgba(255, 85, 0, 0.08) 0%, transparent 60%),
-    radial-gradient(ellipse 60% 80% at 90% 20%, rgba(255, 140, 0, 0.06) 0%, transparent 55%),
-    radial-gradient(ellipse 70% 50% at 50% 50%, rgba(180, 60, 0, 0.04) 0%, transparent 50%),
-    linear-gradient(135deg, #F4F0EC 0%, #F8F4F0 30%, #F2EDE8 60%, #F6F0EA 100%);
+    radial-gradient(ellipse 80% 60% at 10% 90%, rgba(255, 85, 0, 0.14) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 80% at 90% 20%, rgba(255, 140, 0, 0.08) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 50% at 50% 50%, rgba(180, 60, 0, 0.06) 0%, transparent 50%),
+    linear-gradient(135deg, #060810 0%, #0A0D18 30%, #08060E 60%, #0A0710 100%);
   background-size: 200% 200%;
   animation: tml-mesh-shift 12s ease-in-out infinite;
 }
@@ -1642,13 +1643,13 @@ body::after {
   font-family: var(--font-display);
   font-weight: 800;
   font-size: 1.75rem;
-  color: var(--tml-ink);
+  color: #fff;
   margin: 0;
   letter-spacing: -0.03em;
 }
 
 .tml-hero__title-gradient {
-  background: linear-gradient(135deg, var(--tml-navy) 0%, #CC5500 40%, #FF8C00 100%);
+  background: linear-gradient(135deg, #FFFFFF 0%, #FFD4A8 40%, #FF8C00 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -1657,7 +1658,7 @@ body::after {
 .tml-hero__subtitle {
   font-family: var(--font-body);
   font-size: 0.8125rem;
-  color: var(--tml-ink-muted);
+  color: rgba(255, 255, 255, 0.4);
   margin: 0;
   letter-spacing: 0.01em;
 }
@@ -1665,13 +1666,13 @@ body::after {
 .tml-hero__desc {
   font-family: var(--font-body);
   font-size: 0.9375rem;
-  color: var(--tml-ink-secondary);
+  color: rgba(255, 255, 255, 0.6);
   margin: 0;
   line-height: 1.7;
 }
 
 .tml-hero__desc strong {
-  color: var(--tml-orange-dark);
+  color: #FFB347;
   font-weight: 600;
 }
 
@@ -1731,7 +1732,7 @@ body::after {
   position: relative;
   margin-top: 28px;
   height: 4px;
-  background: rgba(0, 0, 0, 0.06);
+  background: rgba(255, 255, 255, 0.05);
   border-radius: 4px;
   overflow: visible;
   z-index: 3;
@@ -1767,44 +1768,10 @@ body::after {
 }
 
 /* 히어로 안 프로그레스 링 색상 오버라이드 */
-.tml-hero .tml-progress-ring__percent { color: var(--tml-ink); }
-.tml-hero .tml-progress-ring__unit { color: var(--tml-orange); }
-.tml-hero .tml-progress-ring__svg circle:first-of-type { stroke: rgba(255, 107, 0, 0.15); }
+.tml-hero .tml-progress-ring__percent { color: #fff; }
+.tml-hero .tml-progress-ring__unit { color: rgba(255, 200, 150, 0.5); }
+.tml-hero .tml-progress-ring__svg circle:first-of-type { stroke: rgba(255, 107, 0, 0.1); }
 
-[data-theme="dark"] .tml-hero {
-  background: #060810;
-  border-color: rgba(255, 107, 0, 0.1);
-  box-shadow:
-    0 0 0 1px rgba(255, 107, 0, 0.06),
-    0 4px 32px rgba(0, 0, 0, 0.6),
-    0 20px 60px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.02);
-}
-
-[data-theme="dark"] .tml-hero__mesh {
-  background:
-    radial-gradient(ellipse 80% 60% at 10% 90%, rgba(255, 85, 0, 0.14) 0%, transparent 60%),
-    radial-gradient(ellipse 60% 80% at 90% 20%, rgba(255, 140, 0, 0.08) 0%, transparent 55%),
-    radial-gradient(ellipse 70% 50% at 50% 50%, rgba(180, 60, 0, 0.06) 0%, transparent 50%),
-    linear-gradient(135deg, #060810 0%, #0A0D18 30%, #08060E 60%, #0A0710 100%);
-  background-size: 200% 200%;
-  animation: tml-mesh-shift 12s ease-in-out infinite;
-}
-
-[data-theme="dark"] .tml-hero__title-gradient {
-  background: linear-gradient(135deg, #FFFFFF 0%, #FFD4A8 40%, #FF8C00 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-[data-theme="dark"] .tml-hero__bar {
-  background: rgba(255, 255, 255, 0.05);
-}
-
-[data-theme="dark"] .tml-hero .tml-progress-ring__percent { color: #fff; }
-[data-theme="dark"] .tml-hero .tml-progress-ring__unit { color: rgba(255, 200, 150, 0.5); }
-[data-theme="dark"] .tml-hero .tml-progress-ring__svg circle:first-of-type { stroke: rgba(255, 107, 0, 0.1); }
 
 @media (max-width: 768px) {
   .tml-hero { padding: 32px 24px 16px; border-radius: 16px; }


### PR DESCRIPTION
## Summary
- 대시보드 히어로 섹션을 다크 스타일로 통일
- `[data-theme="dark"]` 오버라이드 제거 (52줄 → 19줄)
- 라이트/다크 분기 없이 단일 스타일로 유지보수성 개선

## Test plan
- [ ] 대시보드 페이지에서 히어로 섹션 스타일 정상 확인
- [ ] 다크 모드 토글 시 히어로 깨짐 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)