### PR TITLE
fix: 폰트 Pretendard 통일 + 스탯 칩 겹침 수정 + 레이아웃 정리

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,7 +1,6 @@
 /* === tell-me-lion Design System === */
 
 /* 1. 폰트 임포트 */
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap');
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable.css');
 
 /* 2. Tailwind */
@@ -49,7 +48,7 @@
   /* === 폰트 === */
   --font-display: 'Pretendard Variable', 'Pretendard', sans-serif;
   --font-body:    'Pretendard Variable', 'Pretendard', sans-serif;
-  --font-mono:    'IBM Plex Mono', 'JetBrains Mono', monospace;
+  --font-mono:    'Pretendard Variable', 'Pretendard', sans-serif;
 }
 
 /* 4. 다크 테마 오버라이드 */
@@ -1475,6 +1474,7 @@ body::after {
 
 .tml-hero {
   position: relative;
+  z-index: 0;
   background: #060810;
   border-radius: 20px;
   padding: 48px 44px 24px;
@@ -1853,6 +1853,8 @@ body::after {
 
 /* ── 스탯 칩 (인라인 컴팩트) ── */
 .tml-stat-chips {
+  position: relative;
+  z-index: 1;
   display: flex;
   gap: 10px;
   margin-bottom: 24px;

--- a/frontend/src/pages/LectureResult.tsx
+++ b/frontend/src/pages/LectureResult.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { ConceptCard } from '../components/ConceptCard'
 import { SkeletonGroup, ErrorCard } from '../components/Skeleton'
 import { ProcessingStatus } from '../components/ProcessingStatus'
@@ -29,8 +29,6 @@ const SECTION_TABS: { key: ResultSection; label: string }[] = [
 
 export function LectureResult() {
   const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-
   const [state, setState] = useState<PageState>({ tag: 'loading' })
   const [activeSection, setActiveSection] = useState<ResultSection>('concepts')
 
@@ -114,7 +112,7 @@ export function LectureResult() {
   // ── 로딩 ──
   if (state.tag === 'loading') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
         <SkeletonGroup count={4} variant="card" />
       </main>
     )
@@ -123,11 +121,8 @@ export function LectureResult() {
   // ── 존재하지 않는 강의 ──
   if (state.tag === 'not-found') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
-          ← 강의 목록
-        </button>
-        <div className="tml-animate" style={{ marginTop: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate">
           <ErrorCard message="존재하지 않는 강의입니다. 강의 ID를 확인해 주세요." />
           <div style={{ marginTop: 20 }}>
             <Link
@@ -146,11 +141,8 @@ export function LectureResult() {
   // ── 에러 ──
   if (state.tag === 'error') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
-          ← 강의 목록
-        </button>
-        <div className="tml-animate" style={{ marginTop: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate">
           <ErrorCard message={state.message} />
         </div>
       </main>
@@ -161,12 +153,8 @@ export function LectureResult() {
   if (state.tag === 'not-processed') {
     const { lecture } = state
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
-          ← 강의 목록
-        </button>
-
-        <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate" style={{ marginBottom: 32 }}>
           <LectureHeader lecture={lecture} />
         </div>
 
@@ -215,12 +203,8 @@ export function LectureResult() {
   if (state.tag === 'processing') {
     const { lecture } = state
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
-          ← 강의 목록
-        </button>
-
-        <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate" style={{ marginBottom: 32 }}>
           <LectureHeader lecture={lecture} />
         </div>
 
@@ -240,14 +224,9 @@ export function LectureResult() {
   const { concepts, learning_points, quizzes } = outputs
 
   return (
-    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-      {/* 뒤로가기 */}
-      <button className="tml-back-btn tml-animate" onClick={() => navigate('/lectures')}>
-        ← 강의 목록
-      </button>
-
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
       {/* 강의 헤더 */}
-      <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+      <div className="tml-animate" style={{ marginBottom: 32 }}>
         <LectureHeader lecture={lecture} outputs={outputs} />
       </div>
 

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -64,7 +64,7 @@ export function QuizPage() {
   // ── 404 ──
   if (state.tag === 'not-found') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
         <div className="tml-animate">
           <ErrorCard message="존재하지 않는 강의입니다." />
         </div>
@@ -75,7 +75,7 @@ export function QuizPage() {
   // ── 미처리 ──
   if (state.tag === 'not-ready') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
         <div className="tml-animate tml-card" style={{ padding: 32, textAlign: 'center' }}>
           <p style={{
             fontFamily: 'var(--font-display)', fontSize: '1.125rem',
@@ -100,7 +100,7 @@ export function QuizPage() {
   // ── 에러 ──
   if (state.tag === 'error') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
         <div className="tml-animate">
           <ErrorCard message={state.message} />
         </div>
@@ -125,7 +125,7 @@ export function QuizPage() {
   ].filter((t) => t.count > 0)
 
   return (
-    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '40px 40px 80px' }}>
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
       {/* 퀴즈 헤더 */}
       <div className="tml-animate" style={{ marginBottom: 32 }}>
         <p style={{

--- a/frontend/src/pages/WeeklyResult.tsx
+++ b/frontend/src/pages/WeeklyResult.tsx
@@ -21,7 +21,6 @@ type PageState =
 
 export function WeeklyResult() {
   const { week: weekParam } = useParams<{ week: string }>()
-  const navigate = useNavigate()
   const week = Number(weekParam)
 
   const [state, setState] = useState<PageState>({ tag: 'loading' })
@@ -114,7 +113,7 @@ export function WeeklyResult() {
   // ── 로딩 ──
   if (state.tag === 'loading') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
         <SkeletonGroup count={4} variant="card" />
       </main>
     )
@@ -123,11 +122,8 @@ export function WeeklyResult() {
   // ── 404 ──
   if (state.tag === 'not-found') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
-          ← 학습 가이드
-        </button>
-        <div className="tml-animate" style={{ marginTop: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate">
           <ErrorCard message="존재하지 않는 주차입니다. 학습 가이드에서 주차를 선택해 주세요." />
           <div style={{ marginTop: 20 }}>
             <Link
@@ -146,11 +142,8 @@ export function WeeklyResult() {
   // ── 에러 ──
   if (state.tag === 'error') {
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
-          ← 학습 가이드
-        </button>
-        <div className="tml-animate" style={{ marginTop: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate">
           <ErrorCard message={state.message} />
         </div>
       </main>
@@ -165,12 +158,8 @@ export function WeeklyResult() {
     const nextWeek = currentIndex < availableWeeks.length - 1 ? availableWeeks[currentIndex + 1] : null
 
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
-          ← 학습 가이드
-        </button>
-
-        <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate" style={{ marginBottom: 32 }}>
           <WeekHeader weekData={weekData} prevWeek={prevWeek} nextWeek={nextWeek} />
         </div>
 
@@ -212,12 +201,8 @@ export function WeeklyResult() {
     const nextWeek = currentIndex < availableWeeks.length - 1 ? availableWeeks[currentIndex + 1] : null
 
     return (
-      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-        <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
-          ← 학습 가이드
-        </button>
-
-        <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+      <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
+        <div className="tml-animate" style={{ marginBottom: 32 }}>
           <WeekHeader weekData={weekData} prevWeek={prevWeek} nextWeek={nextWeek} />
         </div>
 
@@ -270,14 +255,9 @@ export function WeeklyResult() {
   const nextWeek = currentIndex < availableWeeks.length - 1 ? availableWeeks[currentIndex + 1] : null
 
   return (
-    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '56px 40px 80px' }}>
-      {/* 뒤로가기 */}
-      <button className="tml-back-btn tml-animate" onClick={() => navigate('/guides')}>
-        ← 학습 가이드
-      </button>
-
+    <main style={{ maxWidth: 1280, margin: '0 auto', padding: '20px 40px 80px' }}>
       {/* 주차 헤더 */}
-      <div className="tml-animate" style={{ marginTop: 24, marginBottom: 32 }}>
+      <div className="tml-animate" style={{ marginBottom: 32 }}>
         <WeekHeader weekData={weekData} prevWeek={prevWeek} nextWeek={nextWeek} />
       </div>
 


### PR DESCRIPTION
## Summary
- **폰트 통일**: `--font-mono`를 IBM Plex Mono → Pretendard로 변경, 불필요한 Google Fonts import 제거
- **스탯 칩 겹침 수정**: HeroCard `z-index: 0` / 스탯 칩 `z-index: 1`로 틸트 애니메이션 시 가려짐 해결
- **페이지 레이아웃 정리**: LectureResult·WeeklyResult 뒤로가기 버튼 제거, 전체 페이지 상단 패딩 `20px`로 통일

## Test plan
- [ ] 대시보드에서 HeroCard 호버 시 스탯 칩이 가려지지 않는지 확인
- [ ] 전체 페이지에서 IBM Plex Mono 폰트가 남아있지 않은지 확인
- [ ] LectureResult·WeeklyResult·QuizPage 상단 여백 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)