### PR TITLE
feat: 분석 대기 패널 강조 + 히어로 섀도 수정 + 브레드크럼 정렬

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -131,7 +131,7 @@ function App() {
       {/* 브레드크럼 (상세 페이지에서만) */}
       {showBreadcrumb && (
         <div style={{
-          maxWidth: 1280, margin: '0 auto', padding: '20px 40px 0',
+          maxWidth: 1280, margin: '0 auto', padding: '28px 40px 20px',
         }}>
           <NavBreadcrumb />
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -293,14 +293,7 @@ body::after {
 }
 
 .section-label::before {
-  content: '';
-  position: absolute;
-  top: -1px;
-  left: 0;
-  width: 48px;
-  height: 2px;
-  background: linear-gradient(90deg, var(--tml-orange), transparent);
-  border-radius: 1px;
+  display: none;
 }
 
 /* 핵심 개념 카드 */
@@ -1483,8 +1476,8 @@ body::after {
   border: 1px solid rgba(255, 107, 0, 0.1);
   box-shadow:
     0 0 0 1px rgba(255, 107, 0, 0.06),
-    0 4px 32px rgba(0, 0, 0, 0.6),
-    0 20px 60px rgba(0, 0, 0, 0.5),
+    0 4px 16px rgba(0, 0, 0, 0.35),
+    0 8px 24px rgba(0, 0, 0, 0.2),
     inset 0 1px 0 rgba(255, 255, 255, 0.02);
   will-change: transform;
 }
@@ -2638,6 +2631,109 @@ body::after {
   padding: 14px 16px;
 }
 
+/* ── 분석 대기 섹션 강조 (애니메이션 보더 + 글로우) ── */
+.tml-right-panel__section--queue {
+  position: relative;
+  border: 2px solid transparent;
+  background:
+    linear-gradient(135deg, rgba(255, 107, 0, 0.04), rgba(255, 180, 80, 0.06), rgba(255, 107, 0, 0.03)) padding-box,
+    conic-gradient(from var(--queue-angle, 0deg), var(--tml-orange), rgba(255, 180, 80, 0.6), var(--tml-orange-dark), rgba(255, 140, 0, 0.4), var(--tml-orange)) border-box;
+  border-radius: 12px;
+  padding: 18px 18px;
+  box-shadow:
+    0 0 16px rgba(255, 107, 0, 0.12),
+    0 0 32px rgba(255, 107, 0, 0.06),
+    0 4px 20px rgba(255, 107, 0, 0.08);
+  animation: queue-border-rotate 4s linear infinite, queue-glow-pulse 3s ease-in-out infinite;
+  transform: scale(1.02);
+}
+
+@property --queue-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes queue-border-rotate {
+  to { --queue-angle: 360deg; }
+}
+
+@keyframes queue-glow-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 16px rgba(255, 107, 0, 0.12),
+      0 0 32px rgba(255, 107, 0, 0.06),
+      0 4px 20px rgba(255, 107, 0, 0.08);
+  }
+  50% {
+    box-shadow:
+      0 0 24px rgba(255, 107, 0, 0.22),
+      0 0 48px rgba(255, 107, 0, 0.10),
+      0 6px 28px rgba(255, 107, 0, 0.14);
+  }
+}
+
+/* 선택된 강의가 있을 때 글로우 폭발 */
+.tml-right-panel__section--queue.tml-right-panel__section--has-items {
+  border-width: 3px;
+  box-shadow:
+    0 0 24px rgba(255, 107, 0, 0.25),
+    0 0 48px rgba(255, 107, 0, 0.12),
+    0 8px 32px rgba(255, 107, 0, 0.16);
+  animation: queue-border-rotate 3s linear infinite, queue-glow-pulse-active 2s ease-in-out infinite;
+  transform: scale(1.04);
+}
+
+@keyframes queue-glow-pulse-active {
+  0%, 100% {
+    box-shadow:
+      0 0 24px rgba(255, 107, 0, 0.25),
+      0 0 48px rgba(255, 107, 0, 0.12),
+      0 8px 32px rgba(255, 107, 0, 0.16);
+  }
+  50% {
+    box-shadow:
+      0 0 36px rgba(255, 107, 0, 0.35),
+      0 0 64px rgba(255, 107, 0, 0.18),
+      0 10px 40px rgba(255, 107, 0, 0.22);
+  }
+}
+
+/* 다크 모드 오버라이드 */
+[data-theme="dark"] .tml-right-panel__section--queue {
+  background:
+    linear-gradient(135deg, rgba(255, 107, 0, 0.08), rgba(255, 140, 0, 0.05), rgba(255, 107, 0, 0.06)) padding-box,
+    conic-gradient(from var(--queue-angle, 0deg), var(--tml-orange), rgba(255, 180, 80, 0.6), var(--tml-orange-dark), rgba(255, 140, 0, 0.4), var(--tml-orange)) border-box;
+}
+
+/* 빈 상태 안내 강화 */
+.tml-right-panel__hint {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 0 4px;
+}
+
+.tml-right-panel__hint-icon {
+  font-size: 1.5rem;
+  animation: queue-hint-bounce 2s ease-in-out infinite;
+}
+
+@keyframes queue-hint-bounce {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-6px); }
+}
+
+.tml-right-panel__hint-text {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--tml-orange);
+  text-align: center;
+  margin: 0;
+}
+
 .tml-right-panel__section-title {
   font-family: var(--font-body);
   font-size: 0.75rem;
@@ -3003,7 +3099,7 @@ body::after {
   align-items: center;
   gap: 8px;
   flex: 1;
-  padding: 0 24px;
+  padding: 0;
 }
 
 .tml-header__back {

--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -335,12 +335,15 @@ function RightPanel({
   return (
     <aside className="tml-right-panel">
       {/* 분석 대기 */}
-      <div className="tml-right-panel__section">
-        <p className="tml-right-panel__section-title">
+      <div className={`tml-right-panel__section tml-right-panel__section--queue${selectedIds.size > 0 ? ' tml-right-panel__section--has-items' : ''}`}>
+        <p className="tml-right-panel__section-title" style={{ color: 'var(--tml-orange)' }}>
           분석 대기 ({selectedIds.size}개)
         </p>
         {selectedLectures.length === 0 ? (
-          <p className="tml-right-panel__empty">강의를 선택하세요</p>
+          <div className="tml-right-panel__hint">
+            <span className="tml-right-panel__hint-icon">👈</span>
+            <p className="tml-right-panel__hint-text">왼쪽 강의를 클릭해서 선택하세요</p>
+          </div>
         ) : (
           <ul className="tml-right-panel__list">
             {selectedLectures.map((l) => (
@@ -365,7 +368,7 @@ function RightPanel({
             width: '100%',
             marginTop: 12,
             fontSize: '0.8125rem',
-            padding: '8px 14px',
+            padding: '10px 14px',
             opacity: selectedIds.size === 0 ? 0.4 : 1,
             cursor: selectedIds.size === 0 ? 'not-allowed' : 'pointer',
           }}


### PR DESCRIPTION
## Summary
- **분석 대기 패널**: 회전 conic-gradient 보더 + 글로우 펄스 애니메이션 + 선택 시 강조 폭발 효과 + 빈 상태 안내 강화
- **히어로 섀도 축소**: box-shadow spread 대폭 줄여 스탯 칩 가려짐 해결
- **브레드크럼 정렬**: 좌측 패딩 일치 + 상하 여백 증가
- **section-label 꼬다리 제거**: 오렌지 그라데이션 데코 라인 삭제

## Test plan
- [ ] 강의 목록 페이지에서 분석 대기 패널의 보더 회전 애니메이션 확인
- [ ] 강의 선택 시 글로우 강화 효과 확인
- [ ] 대시보드 히어로 카드 아래 스탯 칩이 가려지지 않는지 확인
- [ ] 강의 결과 페이지 브레드크럼 좌측 정렬 확인
- [ ] 다크 모드에서도 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)