### PR TITLE
fix: 오른쪽 패널 sticky 위치 header 잘림 수정

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2618,7 +2618,7 @@ body::after {
 /* 오른쪽 패널 */
 .tml-right-panel {
   position: sticky;
-  top: 24px;
+  top: 80px;
   display: flex;
   flex-direction: column;
   gap: 12px;


### PR DESCRIPTION
## Summary
- 강의목록 페이지 오른쪽 패널(분석 대기/완료/학습 가이드) sticky `top` 값 수정
- `top: 24px` → `top: 80px` (header 56px + 여백 24px)
- 스크롤 시 분석 대기 카드 상단이 header 뒤로 잘리는 문제 해결

## Test plan
- [ ] 강의목록 페이지에서 스크롤 시 오른쪽 패널이 header 아래에서 정상적으로 sticky 되는지 확인
- [ ] 분석 대기 카드 상단이 잘리지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)