### PR TITLE
fix: 파이프라인 산출물 파일명 불일치 수정

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -204,15 +204,12 @@ def _exec_preprocess(lecture_id: str) -> None:
 def _exec_ep(lecture_id: str) -> None:
     """EP 실행 (개념 + 학습 포인트 추출)."""
     from pipeline.ep.runner import run_ep
-    from pipeline.preprocessor.wrapper import _find_output_file
+    from pipeline.paths import DATA_PHASE5_FACTS
 
-    # Phase 5 출력 중 해당 강의 파일만 처리
-    phase5_file = _find_output_file(DATA_EP_CONCEPTS.parent / "phase5_facts", lecture_id)
-    if phase5_file:
-        run_ep(
-            in_dir=phase5_file.parent,
-            out_dir=DATA_EP_CONCEPTS,
-        )
+    # wrapper.py에서 정규화된 {lecture_id}.jsonl 파일 사용
+    phase5_file = DATA_PHASE5_FACTS / f"{lecture_id}.jsonl"
+    if phase5_file.exists():
+        run_ep(input_file=phase5_file, out_dir=DATA_EP_CONCEPTS)
     else:
         run_ep()
 

--- a/pipeline/ep/runner.py
+++ b/pipeline/ep/runner.py
@@ -13,6 +13,7 @@ from .learning_point_extractor import extract_learning_points
 def run_ep(
     in_dir: Path | None = None,
     out_dir: Path | None = None,
+    input_file: Path | None = None,
 ) -> None:
     """phase5_facts에서 핵심 개념 + 학습 포인트를 추출.
 
@@ -21,14 +22,17 @@ def run_ep(
       - data/ep_concepts/*.jsonl (핵심 개념)
       - data/ep_learning_points/*.jsonl (학습 포인트)
     """
-    src = in_dir or paths.DATA_PHASE5_FACTS
     dst_concepts = out_dir or paths.DATA_EP_CONCEPTS
     dst_lp = paths.DATA_EP_LEARNING_POINTS
     dst_concepts.mkdir(parents=True, exist_ok=True)
     dst_lp.mkdir(parents=True, exist_ok=True)
 
     # 입력 파일 목록
-    jsonl_files = sorted(src.glob("*.jsonl"))
+    if input_file is not None:
+        jsonl_files = [input_file]
+    else:
+        src = in_dir or paths.DATA_PHASE5_FACTS
+        jsonl_files = sorted(src.glob("*.jsonl"))
 
     for jsonl_file in jsonl_files:
         # 파일명 파싱

--- a/pipeline/preprocessor/wrapper.py
+++ b/pipeline/preprocessor/wrapper.py
@@ -102,6 +102,16 @@ def run_preprocess(
     formatter.format_documents(phase3_file, phase4_file, paths.DATA_PHASE5_FACTS)
     logger.info("[Phase 5] Formatter 완료")
 
+    # Phase 5 출력 파일을 lecture_id 기반 파일명으로 정규화
+    # (Formatter가 {date}_chunks_formatted.jsonl 로 저장하므로 {lecture_id}.jsonl 로 복사)
+    import shutil
+    date_part = lecture_id.split("_")[0]
+    chunks_src = paths.DATA_PHASE5_FACTS / f"{date_part}_chunks_formatted.jsonl"
+    chunks_dst = paths.DATA_PHASE5_FACTS / f"{lecture_id}.jsonl"
+    if chunks_src.exists() and chunks_src != chunks_dst:
+        shutil.copy2(chunks_src, chunks_dst)
+        logger.info("[Phase 5] 파일명 정규화: %s → %s", chunks_src.name, chunks_dst.name)
+
 
 def _find_output_file(directory: Path, lecture_id: str) -> Path | None:
     """출력 디렉터리에서 lecture_id와 매칭되는 JSONL 파일을 찾는다.


### PR DESCRIPTION
## 문제

강의 분석 완료 후에도 카드가 계속 `idle` 상태로 표시되는 버그.

파이프라인이 산출물을 `{date}_chunks_formatted.jsonl` 형식으로 저장했지만,
백엔드(`catalog.py`)는 `{lecture_id}.jsonl` 형식을 기대하여 완료를 감지하지 못함.

## 수정 내용

- **`wrapper.py`**: Phase 5 완료 후 `{lecture_id}.jsonl`로 정규화 복사
- **`ep/runner.py`**: `input_file` 파라미터 추가 — 단일 파일 직접 처리 지원
- **`routes.py`**: `_exec_ep()`에서 정규화된 파일명 직접 참조

## 수정 후 동작

1. 파이프라인 완료 → `phase5_facts/{lecture_id}.jsonl` 생성
2. EP → `ep_concepts/{lecture_id}.jsonl` 생성
3. 백엔드 `_get_status()` 파일 감지 성공 → `completed` 반환
4. 새로고침해도 완료 카드·상태바 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)