### PR TITLE
fix: 강의/주차 분석 상태 관리 버그 7건 수정 (TASK-037)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -341,6 +341,7 @@ async def get_lecture_results(lecture_id: str):
     is_completed = (
         (job and job.status == ProcessingStatus.completed)
         or lec.status == ProcessingStatus.completed
+        or (DATA_EP_CONCEPTS / f"{lecture_id}.jsonl").exists()
     )
     if not is_completed:
         return JSONResponse(status_code=202, content={"status": "processing"})
@@ -437,6 +438,7 @@ async def get_week_results(week: int):
     is_completed = (
         (job and job.status == ProcessingStatus.completed)
         or ws.status == ProcessingStatus.completed
+        or (DATA_LEARNING_GUIDES / f"week_{week:02d}.jsonl").exists()
     )
     if not is_completed:
         return JSONResponse(status_code=202, content={"status": "processing"})

--- a/frontend/src/components/ProcessingStatus.tsx
+++ b/frontend/src/components/ProcessingStatus.tsx
@@ -12,9 +12,14 @@ interface ProcessingStatusProps {
 }
 
 const DEFAULT_STEPS: ProcessingStep[] = [
-  { name: '영상 분석', status: 'pending' },
-  { name: '텍스트 추출', status: 'pending' },
-  { name: 'AI 분석', status: 'pending' },
+  { name: '전처리', status: 'pending' },
+  { name: '개념 추출', status: 'pending' },
+  { name: '문제 설계', status: 'pending' },
+  { name: '퀴즈 생성', status: 'pending' },
+]
+
+const DEFAULT_WEEK_STEPS: ProcessingStep[] = [
+  { name: '학습 가이드 생성', status: 'pending' },
 ]
 
 function calcPercent(steps: ProcessingStep[]): number {
@@ -59,7 +64,8 @@ export function ProcessingStatus({
     onError,
   })
 
-  const steps = (status?.steps && status.steps.length > 0) ? status.steps : DEFAULT_STEPS
+  const defaultSteps = week !== undefined ? DEFAULT_WEEK_STEPS : DEFAULT_STEPS
+  const steps = (status?.steps && status.steps.length > 0) ? status.steps : defaultSteps
   const percent = calcPercent(steps)
   const elapsed = useElapsed(status?.started_at)
 

--- a/frontend/src/hooks/useProcessingStatus.ts
+++ b/frontend/src/hooks/useProcessingStatus.ts
@@ -1,4 +1,4 @@
-/* useProcessingStatus — 강의/주차 처리 상태를 2초 간격으로 폴링한다. */
+/* useProcessingStatus — 강의/주차 처리 상태를 10초 간격으로 폴링한다. */
 
 import { useEffect, useRef, useState } from 'react'
 import type { ProcessingStatusResponse } from '../types/models'
@@ -23,7 +23,7 @@ export function useProcessingStatus({
   lectureId,
   week,
   enabled,
-  interval = 30000,
+  interval = 10000,
   onComplete,
   onError,
 }: UseProcessingStatusOptions): UseProcessingStatusReturn {
@@ -49,9 +49,21 @@ export function useProcessingStatus({
     let timer: ReturnType<typeof setTimeout>
     let retryCount = 0
     const MAX_RETRIES = 5
+    const MAX_POLL_MS = 60 * 60 * 1000 // 60분 타임아웃
+    const pollStartTime = Date.now()
 
     async function poll() {
       if (stopped) return
+
+      // BUG-2: 전체 폴링 타임아웃
+      if (Date.now() - pollStartTime > MAX_POLL_MS) {
+        const msg = '처리 시간이 초과되었습니다. 서버 상태를 확인해 주세요.'
+        console.error(`[폴링] 전체 타임아웃 초과 (${MAX_POLL_MS / 60000}분)`)
+        setError(msg)
+        onErrorRef.current?.(msg)
+        return
+      }
+
       const target = lectureId ? `lecture:${lectureId}` : `week:${week}`
       console.log(`[폴링] ${target} — 상태 조회 중... (재시도: ${retryCount})`)
       try {

--- a/frontend/src/pages/GuidesPage.tsx
+++ b/frontend/src/pages/GuidesPage.tsx
@@ -157,7 +157,7 @@ export function GuidesPage() {
 
   const getEffectiveStatus = (ws: WeekSummary): ProcessingStatus => {
     if (processingWeeks.has(ws.week)) return 'processing'
-    if (ws.status === 'processing' && !processingWeeks.has(ws.week)) return 'idle'
+    if (ws.status === 'processing') return 'processing'
     return ws.status
   }
 

--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -255,11 +255,7 @@ function WeekSection({
 }: WeekSectionProps) {
   const { week, lecture_count, completed_count, date_range, lectures } = weekSummary
 
-  const effectiveWeekStatus: ProcessingStatus = processingWeeks.has(week)
-    ? 'processing'
-    : weekSummary.status === 'processing' && !processingWeeks.has(week)
-      ? 'idle'
-      : weekSummary.status
+  const effectiveWeekStatus = getEffectiveWeekStatus(week, weekSummary.status, processingWeeks)
 
   return (
     <section className="tml-week-section tml-animate">
@@ -461,19 +457,24 @@ export function LecturesPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
 
-  // 서버에서 processing 상태인 강의를 로컬 상태에 동기화 (새로고침 후 상태바 복원)
+  // 서버 상태와 로컬 processingSet 동기화 (새로고침/뒤로가기 대응)
   useEffect(() => {
-    const ids = weeks
-      .flatMap((w) => w.lectures)
-      .filter((l) => l.status === 'processing')
-      .map((l) => l.lecture_id)
-    if (ids.length > 0) {
-      setProcessingLectures((prev) => {
-        const next = new Set(prev)
-        ids.forEach((id) => next.add(id))
-        return next
-      })
-    }
+    const allLectures = weeks.flatMap((w) => w.lectures)
+    const serverProcessingIds = new Set(
+      allLectures.filter((l) => l.status === 'processing').map((l) => l.lecture_id),
+    )
+    const serverCompletedIds = new Set(
+      allLectures.filter((l) => l.status === 'completed').map((l) => l.lecture_id),
+    )
+
+    setProcessingLectures((prev) => {
+      const next = new Set(prev)
+      // 서버에서 processing인 강의 추가
+      serverProcessingIds.forEach((id) => next.add(id))
+      // 서버에서 completed인 강의는 제거 (BUG-1: 뒤로가기 시 고착 방지)
+      serverCompletedIds.forEach((id) => next.delete(id))
+      return next
+    })
   }, [weeks])
 
   const activeWeek = searchParams.get('week') ? Number(searchParams.get('week')) : null
@@ -512,7 +513,7 @@ export function LecturesPage() {
       ids.map(async (id) => {
         setProcessingLectures((prev) => new Set(prev).add(id))
         try {
-          await triggerLectureProcess(id, true)
+          await triggerLectureProcess(id, false)
         } catch {
           failed.push(id)
           setProcessingLectures((prev) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -104,9 +104,17 @@ export async function fetchWeekStatus(week: number): Promise<ProcessingStatusRes
 // ===== 결과 =====
 
 export async function fetchLectureResults(lectureId: string): Promise<LectureOutputs> {
-  return request(`/api/lectures/${lectureId}/results`)
+  const data = await request<LectureOutputs & { status?: string }>(`/api/lectures/${lectureId}/results`)
+  if (data.status === 'processing') {
+    throw new ApiError(202, '아직 처리가 완료되지 않았습니다.')
+  }
+  return data
 }
 
 export async function fetchWeekResults(week: number): Promise<WeeklyOutputs> {
-  return request(`/api/weeks/${week}/results`)
+  const data = await request<WeeklyOutputs & { status?: string }>(`/api/weeks/${week}/results`)
+  if (data.status === 'processing') {
+    throw new ApiError(202, '아직 처리가 완료되지 않았습니다.')
+  }
+  return data
 }

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -18,7 +18,7 @@ export function getEffectiveLectureStatus(
 /**
  * 주차의 실제 처리 상태를 반환한다.
  * - 로컬 processingSet에 있으면 'processing'
- * - 서버가 processing인데 로컬에 없으면 'idle' (이전 세션 잔여)
+ * - 서버가 processing이면 'processing' (다른 세션에서 시작한 경우 포함)
  * - 그 외: 서버 상태
  */
 export function getEffectiveWeekStatus(
@@ -27,6 +27,6 @@ export function getEffectiveWeekStatus(
   processingSet: Set<number>,
 ): ProcessingStatus {
   if (processingSet.has(week)) return 'processing'
-  if (serverStatus === 'processing' && !processingSet.has(week)) return 'idle'
+  if (serverStatus === 'processing') return 'processing'
   return serverStatus
 }


### PR DESCRIPTION
## Summary
- BUG-1: 분석 완료 후 뒤로가기 시 카드가 processing에 걸리는 버그 수정 (processingSet ↔ 서버 상태 동기화)
- BUG-2: 폴링 전체 타임아웃 60분 추가 (무한 대기 방지)
- BUG-3: `triggerLectureProcess` force=true → false 변경 (idle만 선택 가능하므로 안전)
- BUG-4: DEFAULT_STEPS를 실제 파이프라인 4단계(전처리/개념 추출/문제 설계/퀴즈 생성)로 일치 + 주차용 별도 정의
- BUG-5: 서버가 processing 상태이면 로컬 Set과 무관하게 processing 표시 (GuidesPage, LecturesPage, RightPanel 전체 수정)
- BUG-6: 결과 API is_completed에 파일 존재 여부 fallback 추가 (강의+주차) + 프론트에서 202 응답 에러 처리
- BUG-7: 폴링 간격 30초 → 10초로 단축

## 변경 파일
- `app/api/routes.py` — is_completed fallback
- `frontend/src/components/ProcessingStatus.tsx` — DEFAULT_STEPS 4단계 + 주차용
- `frontend/src/hooks/useProcessingStatus.ts` — 10초 간격 + 60분 타임아웃
- `frontend/src/pages/GuidesPage.tsx` — BUG-5 수정
- `frontend/src/pages/LecturesPage.tsx` — BUG-1, BUG-3, BUG-5 수정
- `frontend/src/services/api.ts` — 202 응답 처리
- `frontend/src/utils/status.ts` — getEffectiveWeekStatus 수정

## Test plan
- [ ] 강의 분석 시작 → 진행률 4단계 확인 → 완료 후 결과 페이지 이동
- [ ] 결과 페이지에서 뒤로가기 → 카드가 completed 상태인지 확인 (BUG-1)
- [ ] 학습 가이드 페이지에서 다른 세션의 processing 주차가 표시되는지 확인 (BUG-5)
- [ ] 60분 이상 폴링 시 타임아웃 에러 전환 확인 (BUG-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)