### PR TITLE
fix/feat: 디자인 감사 수정 + 백엔드 버그 4건 수정 (TASK-038, TASK-039)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -223,12 +223,10 @@ def _exec_ep(lecture_id: str) -> None:
     from pipeline.ep.runner import run_ep
     from pipeline.paths import DATA_PHASE5_FACTS
 
-    # wrapper.py에서 정규화된 {lecture_id}.jsonl 파일 사용
     phase5_file = DATA_PHASE5_FACTS / f"{lecture_id}.jsonl"
-    if phase5_file.exists():
-        run_ep(input_file=phase5_file, out_dir=DATA_EP_CONCEPTS)
-    else:
-        run_ep()
+    if not phase5_file.exists():
+        raise FileNotFoundError(f"전처리 출력 파일 없음: {phase5_file}")
+    run_ep(input_file=phase5_file, out_dir=DATA_EP_CONCEPTS)
 
 
 def _exec_blueprint(lecture_id: str) -> None:
@@ -236,10 +234,9 @@ def _exec_blueprint(lecture_id: str) -> None:
     from pipeline.blueprint.runner import run_blueprint
 
     ep_file = DATA_EP_CONCEPTS / f"{lecture_id}.jsonl"
-    if ep_file.exists():
-        run_blueprint(input_file=ep_file)
-    else:
-        run_blueprint()
+    if not ep_file.exists():
+        raise FileNotFoundError(f"EP 출력 파일 없음: {ep_file}")
+    run_blueprint(input_file=ep_file)
 
 
 def _exec_quiz_generation(lecture_id: str) -> None:
@@ -248,13 +245,12 @@ def _exec_quiz_generation(lecture_id: str) -> None:
     from pipeline.paths import DATA_BLUEPRINTS, DATA_QUIZZES_RAW
 
     bp_file = DATA_BLUEPRINTS / f"{lecture_id}.jsonl"
-    if bp_file.exists():
-        run_quiz_generation(
-            input_file=bp_file,
-            output_file=DATA_QUIZZES_RAW / f"{lecture_id}.jsonl",
-        )
-    else:
-        run_quiz_generation()
+    if not bp_file.exists():
+        raise FileNotFoundError(f"Blueprint 출력 파일 없음: {bp_file}")
+    run_quiz_generation(
+        input_file=bp_file,
+        output_file=DATA_QUIZZES_RAW / f"{lecture_id}.jsonl",
+    )
 
     # quizzes_raw → quizzes_validated 복사 (QA 별도 단계 불필요)
     raw_file = DATA_QUIZZES_RAW / f"{lecture_id}.jsonl"
@@ -284,7 +280,7 @@ async def process_lecture(
 ):
     """강의 처리 시작 트리거 (Mode A)."""
     _validate_lecture_id(lecture_id)
-    lectures = load_lectures()
+    lectures = await asyncio.to_thread(load_lectures)
     if not any(lec.lecture_id == lecture_id for lec in lectures):
         raise HTTPException(status_code=404, detail=f"강의 {lecture_id}를 찾을 수 없습니다.")
 
@@ -316,7 +312,7 @@ async def process_lecture(
 async def get_lecture_status(lecture_id: str):
     """강의 처리 상태 조회."""
     _validate_lecture_id(lecture_id)
-    lectures = load_lectures()
+    lectures = await asyncio.to_thread(load_lectures)
     lec = next((l for l in lectures if l.lecture_id == lecture_id), None)
     if not lec:
         raise HTTPException(status_code=404, detail=f"강의 {lecture_id}를 찾을 수 없습니다.")
@@ -342,7 +338,7 @@ async def get_lecture_status(lecture_id: str):
 async def get_lecture_results(lecture_id: str):
     """강의 처리 결과 조회. 완료 전이면 202 반환."""
     _validate_lecture_id(lecture_id)
-    lectures = load_lectures()
+    lectures = await asyncio.to_thread(load_lectures)
     lec = next((l for l in lectures if l.lecture_id == lecture_id), None)
     if not lec:
         raise HTTPException(status_code=404, detail=f"강의 {lecture_id}를 찾을 수 없습니다.")
@@ -384,7 +380,7 @@ async def get_lecture_results(lecture_id: str):
 async def process_week(week: int, background_tasks: BackgroundTasks, force: bool = False):
     """주차 처리 시작 트리거 (Mode B)."""
     _validate_week(week)
-    weeks = load_weeks()
+    weeks = await asyncio.to_thread(load_weeks)
     if not any(w.week == week for w in weeks):
         raise HTTPException(status_code=404, detail=f"{week}주차 데이터를 찾을 수 없습니다.")
 
@@ -416,7 +412,7 @@ async def process_week(week: int, background_tasks: BackgroundTasks, force: bool
 async def get_week_status(week: int):
     """주차 처리 상태 조회."""
     _validate_week(week)
-    weeks = load_weeks()
+    weeks = await asyncio.to_thread(load_weeks)
     ws = next((w for w in weeks if w.week == week), None)
     if not ws:
         raise HTTPException(status_code=404, detail=f"{week}주차 데이터를 찾을 수 없습니다.")
@@ -439,7 +435,7 @@ async def get_week_status(week: int):
 async def get_week_results(week: int):
     """주차 처리 결과 조회. 완료 전이면 202 반환."""
     _validate_week(week)
-    weeks = load_weeks()
+    weeks = await asyncio.to_thread(load_weeks)
     ws = next((w for w in weeks if w.week == week), None)
     if not ws:
         raise HTTPException(status_code=404, detail=f"{week}주차 데이터를 찾을 수 없습니다.")

--- a/app/loaders/catalog.py
+++ b/app/loaders/catalog.py
@@ -47,7 +47,11 @@ def _calculate_week(lecture_date: date, first_date: date) -> int:
 
 def _get_status(lecture_id: str) -> ProcessingStatus:
     """파이프라인 출력 디렉터리를 확인해 처리 상태를 판별."""
-    if (DATA_EP_CONCEPTS / f"{lecture_id}.jsonl").exists():
+    if (
+        (DATA_EP_CONCEPTS / f"{lecture_id}.jsonl").exists()
+        and (DATA_EP_LEARNING_POINTS / f"{lecture_id}.jsonl").exists()
+        and (DATA_QUIZZES_VALIDATED / f"{lecture_id}.jsonl").exists()
+    ):
         return ProcessingStatus.completed
     if (DATA_PHASE1_SESSIONS / f"{lecture_id}.jsonl").exists():
         return ProcessingStatus.processing
@@ -181,7 +185,7 @@ def load_weeks() -> list[WeekSummary]:
 
         if completed_count == len(week_lectures):
             week_status = ProcessingStatus.completed
-        elif completed_count > 0 or any(l.status == ProcessingStatus.processing for l in week_lectures):
+        elif any(l.status == ProcessingStatus.processing for l in week_lectures):
             week_status = ProcessingStatus.processing
         else:
             week_status = ProcessingStatus.idle

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,6 +51,14 @@
   --font-display: 'Pretendard Variable', 'Pretendard', sans-serif;
   --font-body:    'Pretendard Variable', 'Pretendard', sans-serif;
   --font-mono:    'IBM Plex Mono', 'JetBrains Mono', monospace;
+
+  /* === Border Radius 토큰 === */
+  --radius-xs:   2px;    /* 세로 바, 인라인 요소 */
+  --radius-sm:   4px;    /* 뱃지, 태그 */
+  --radius-md:   6px;    /* 카드, 버튼 (기본) */
+  --radius-lg:   12px;   /* 강조 카드, 통계 */
+  --radius-xl:   20px;   /* 히어로, 프로그레스 바 */
+  --radius-full: 9999px; /* 원형, 필 */
 }
 
 /* 4. 다크 테마 오버라이드 */
@@ -127,6 +135,12 @@ body::after {
   .tml-scroll-reveal { opacity: 1; transform: none; }
 }
 
+/* A-1: 포커스 링 글로벌 스타일 (WCAG 2.1 AA — 2.4.7 Focus Visible) */
+:focus-visible {
+  outline: 2px solid var(--tml-orange);
+  outline-offset: 2px;
+}
+
 /* 스크롤 기반 페이드인 + 슬라이드업 */
 .tml-scroll-reveal {
   opacity: 0;
@@ -166,6 +180,7 @@ body::after {
   letter-spacing: -0.02em;
   color: var(--tml-ink);
   margin: 0 0 28px;
+  text-wrap: balance;
 }
 
 /* 8. 베이스 컴포넌트 */
@@ -240,6 +255,7 @@ body::after {
   left: 150%;
 }
 .btn-primary:active {
+  transform: scale(0.96);
   box-shadow: 0 0 0 2px rgba(255, 107, 0, 0.25);
 }
 
@@ -350,6 +366,7 @@ body::after {
   font-size: 0.9375rem;
   color: var(--tml-ink);
   letter-spacing: -0.01em;
+  text-wrap: balance;
 }
 
 .concept-score {
@@ -638,6 +655,7 @@ body::after {
   font-family: var(--font-mono);
   font-size: 0.75rem;
   color: var(--tml-ink-muted);
+  font-variant-numeric: tabular-nums;
 }
 
 /* 질문 텍스트 */
@@ -649,6 +667,7 @@ body::after {
   line-height: 1.6;
   margin: 0 0 24px;
   letter-spacing: -0.01em;
+  text-wrap: balance;
 }
 
 /* 피드백 배너 */
@@ -1128,6 +1147,7 @@ body::after {
   border-radius: 4px;
   padding: 5px 12px;
   line-height: 1;
+  cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 
@@ -1454,6 +1474,11 @@ body::after {
 
 @media (prefers-reduced-motion: reduce) {
   .tml-dashboard-stagger { animation: none; }
+  .tml-hero__mesh { animation: none; }
+  .tml-hero__orb { animation: none; }
+  .tml-hero__scanline::after { animation: none; }
+  .tml-hero__cta-pulse { animation: none; }
+  .tml-hero__bar-fill::after { animation: none; }
 }
 
 /* ── 히어로 (3D tilt + aurora mesh) ── */
@@ -3343,4 +3368,11 @@ body::after {
   width: 16px;
   display: flex;
   justify-content: center;
+}
+
+/* R-1: 극소형 모바일(375px) padding 과대 방지 */
+@media (max-width: 479px) {
+  .tml-page-container {
+    padding: 16px 16px 60px;
+  }
 }

--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -73,6 +73,13 @@ function LectureCard({ lecture, isSelected, onToggleSelect, onViewResults, onPro
 
   const isClickable = status === 'idle' || status === 'completed'
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (isClickable && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault()
+      handleCardClick()
+    }
+  }
+
   return (
     <div
       className={[
@@ -80,7 +87,10 @@ function LectureCard({ lecture, isSelected, onToggleSelect, onViewResults, onPro
         isClickable ? 'tml-lecture-card--selectable' : '',
         isSelected ? 'tml-lecture-card--selected' : '',
       ].join(' ').trim()}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
       onClick={isClickable ? handleCardClick : undefined}
+      onKeyDown={isClickable ? handleKeyDown : undefined}
     >
       <div className="tml-lecture-card__thumb" style={{ background: gradient, position: 'relative' }}>
         <span className="tml-lecture-card__date-badge">


### PR DESCRIPTION
## 변경 요약

### TASK-039 — 백엔드 버그 4건 수정
- **BUG-1**: 주차 상태 판별에서 `completed_count > 0` 조건 제거 → 일부 강의만 완료된 주차가 `processing`으로 오분류되는 문제 수정
- **BUG-2**: EP/Blueprint/Quiz 단계에서 입력 파일 없을 시 `FileNotFoundError` raise → 전체 디렉터리 처리 방지
- **BUG-3**: async 엔드포인트 6곳에서 `load_lectures/load_weeks` 직접 호출 → `asyncio.to_thread()` 로 변경 (이벤트 루프 블로킹 방지)
- **BUG-4**: `_get_status` 완료 판정을 `ep_concepts` 단독 → concepts + learning_points + quizzes 3개 파일 모두 존재해야 `completed`로 강화

### TASK-038 — 프론트엔드 디자인 감사 수정
- **A-1 (P0/CRITICAL)**: `:focus-visible` 포커스 링 글로벌 스타일 추가 (WCAG 2.1 AA 2.4.7)
- **A-2 (P1)**: `LectureCard` div에 `role="button"`, `tabIndex={0}`, `onKeyDown` 키보드 접근성 추가
- **A-3 (P2)**: 히어로 장식 애니메이션 `prefers-reduced-motion` 대응 (mesh/orb/scanline/pulse/shimmer)
- **T-1 (P2)**: `.tml-page-title`, `.concept-name`, `.quiz-question`에 `text-wrap: balance` 추가
- **T-3 (P2)**: `.quiz-meta-id`에 `font-variant-numeric: tabular-nums` 추가
- **C-1 (P2)**: `:root`에 `--radius-xs/sm/md/lg/xl/full` 디자인 토큰 추가
- **R-1 (P2)**: `max-width: 479px`에서 `.tml-page-container` padding 16px로 축소
- **M-1 (P3)**: `.btn-primary:active`에 `transform: scale(0.96)` 추가
- **C-2 (P3)**: `.tml-concept-tag`에 `cursor: pointer` 추가

## 변경 파일
- `app/api/routes.py`
- `app/loaders/catalog.py`
- `frontend/src/index.css`
- `frontend/src/pages/LecturesPage.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)