### PR TITLE
fix: TASK-042 주차 가이드 상태 판정을 guide_status로 분리

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -419,7 +419,10 @@ async def get_week_status(week: int):
 
     job = await get_week_job(week)
     if not job:
-        return ProcessingStatusResponse(week=week, status=ws.status)
+        # 인메모리 job 없음 (서버 재시작 등) → 가이드 결과 파일로 판정
+        guide_file = DATA_LEARNING_GUIDES / f"week_{week:02d}.jsonl"
+        fallback_status = ProcessingStatus.completed if guide_file.exists() else ProcessingStatus.idle
+        return ProcessingStatusResponse(week=week, status=fallback_status)
 
     return ProcessingStatusResponse(
         week=week,

--- a/app/loaders/catalog.py
+++ b/app/loaders/catalog.py
@@ -11,7 +11,7 @@ import time
 from datetime import date
 from pathlib import Path
 
-from pipeline.paths import DATA_RAW, DATA_EP_CONCEPTS, DATA_EP_LEARNING_POINTS, DATA_QUIZZES_VALIDATED, DATA_PHASE1_SESSIONS
+from pipeline.paths import DATA_RAW, DATA_EP_CONCEPTS, DATA_EP_LEARNING_POINTS, DATA_QUIZZES_VALIDATED, DATA_PHASE1_SESSIONS, DATA_LEARNING_GUIDES
 
 logger = logging.getLogger(__name__)
 from app.schemas.models import (
@@ -190,6 +190,10 @@ def load_weeks() -> list[WeekSummary]:
         else:
             week_status = ProcessingStatus.idle
 
+        # 가이드 결과 파일 존재 여부로 guide_status 결정
+        guide_file = DATA_LEARNING_GUIDES / f"week_{week_num:02d}.jsonl"
+        guide_status = ProcessingStatus.completed if guide_file.exists() else ProcessingStatus.idle
+
         summaries.append(
             WeekSummary(
                 week=week_num,
@@ -197,6 +201,7 @@ def load_weeks() -> list[WeekSummary]:
                 completed_count=completed_count,
                 date_range=date_range,
                 status=week_status,
+                guide_status=guide_status,
                 lectures=week_lectures,
             )
         )

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -145,6 +145,7 @@ class WeekSummary(BaseModel):
     completed_count: int
     date_range: str
     status: ProcessingStatus
+    guide_status: ProcessingStatus = ProcessingStatus.idle
     lectures: list[LectureCatalog] = Field(default_factory=list)
 
 

--- a/frontend/src/pages/GuidesPage.tsx
+++ b/frontend/src/pages/GuidesPage.tsx
@@ -160,8 +160,11 @@ export function GuidesPage() {
   const getEffectiveStatus = (ws: WeekSummary): ProcessingStatus => {
     if (completedWeeks.has(ws.week)) return 'completed'
     if (processingWeeks.has(ws.week)) return 'processing'
-    if (ws.status === 'processing') return 'processing'
-    return ws.status
+    // guide_status 기준 (Mode B 가이드 생성 상태)
+    const guideStatus = ws.guide_status ?? ws.status
+    if (guideStatus === 'completed') return 'completed'
+    if (guideStatus === 'processing') return 'processing'
+    return guideStatus
   }
 
   // 통계 산출

--- a/frontend/src/pages/WeeklyResult.tsx
+++ b/frontend/src/pages/WeeklyResult.tsx
@@ -47,11 +47,13 @@ export function WeeklyResult() {
           return
         }
 
-        if (weekData.status === 'completed') {
+        // guide_status 기준으로 판정 (Mode B 가이드 생성 상태)
+        const guideStatus = weekData.guide_status ?? weekData.status
+        if (guideStatus === 'completed') {
           const outputs = await fetchWeekResults(week)
           if (cancelled) return
           setState({ tag: 'results', week: weekData, outputs, availableWeeks })
-        } else if (weekData.status === 'processing') {
+        } else if (guideStatus === 'processing') {
           setState({ tag: 'processing', week: weekData, availableWeeks })
         } else {
           setState({ tag: 'not-processed', week: weekData, availableWeeks })
@@ -87,10 +89,11 @@ export function WeeklyResult() {
         try {
           const [weekData, allWeeks] = await Promise.all([fetchWeek(week), fetchWeeks()])
           const availableWeeks = allWeeks.map((w) => w.week).sort((a, b) => a - b)
-          if (weekData.status === 'completed') {
+          const gs = weekData.guide_status ?? weekData.status
+          if (gs === 'completed') {
             const outputs = await fetchWeekResults(week)
             setState({ tag: 'results', week: weekData, outputs, availableWeeks })
-          } else if (weekData.status === 'processing') {
+          } else if (gs === 'processing') {
             setState({ tag: 'processing', week: weekData, availableWeeks })
           } else {
             setState({ tag: 'not-processed', week: weekData, availableWeeks })

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -33,6 +33,7 @@ export interface WeekSummary {
   completed_count: number
   date_range: string
   status: ProcessingStatus
+  guide_status: ProcessingStatus
   lectures: Lecture[]
 }
 


### PR DESCRIPTION
## Summary
- `WeekSummary`에 `guide_status` 필드 추가 — 가이드 결과 파일(`week_XX.jsonl`) 존재 여부로 판정
- 기존 `status`(개별 강의 분석 상태)와 분리하여 GuidesPage/WeeklyResult가 가이드 생성 완료를 정확히 표시
- 서버 재시작 후 인메모리 job 소실 시 파일 기반 fallback으로 processing+빈 steps 루프 해소

## 수정된 버그
- GuidesPage "완료된 가이드: 0" → guide_status 기준 카운트
- WeeklyResult "아직 생성되지 않았습니다" (가이드 완료인데도) → guide_status 기준 판정
- 서버 재시작 후 week 폴링 processing+빈 steps 무한 루프 → idle/completed로 정확히 반환

## Test plan
- [ ] 가이드 생성 완료된 주차: GuidesPage에서 "가이드 보기" 버튼, WeeklyResult에서 결과 표시 확인
- [ ] 미생성 주차: "가이드 생성" 버튼 표시 확인
- [ ] 서버 재시작 후 동일 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)