### PR TITLE
docs: CLAUDE.md에 백엔드 자동 배포 정보 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,16 @@ VITE_API_URL=http://15.165.140.229
 
 ## 배포 환경
 
-| 레이어 | 플랫폼 | 주소 |
-|--------|--------|------|
-| 프론트엔드 | Vercel | `wonder-girls.vercel.app` |
-| 백엔드 | AWS EC2 | `15.165.140.229` |
+| 레이어 | 플랫폼 | 주소 | 배포 방식 |
+|--------|--------|------|-----------|
+| 프론트엔드 | Vercel | `wonder-girls.vercel.app` | main push 시 Vercel 자동 배포 |
+| 백엔드 | AWS EC2 | `15.165.140.229` | main push 시 GitHub Actions 자동 배포 |
+
+### 자동 배포 상세
+
+- **프론트엔드**: Vercel이 main 브랜치 push 감지 → 자동 빌드·배포
+- **백엔드**: `.github/workflows/deploy-backend.yml` — main push 시 `app/`, `pipeline/`, `config/`, `requirements.txt`, `scripts/` 경로 변경 감지 → EC2에 SSH 접속 → `git pull` + `docker compose up -d --build` → health check(`/health`)
+- **양쪽 모두 수동 배포 불필요**. PR 머지 = 배포 완료.
 
 ---
 


### PR DESCRIPTION
## Summary
- 배포 환경 섹션에 프론트/백엔드 자동 배포 방식 명시
- GitHub Actions 워크플로우 경로 필터, 배포 절차 상세 기록
- "양쪽 모두 수동 배포 불필요. PR 머지 = 배포 완료" 명확히 기재

## Test plan
- [ ] CLAUDE.md 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)