### PR TITLE
fix: 진행상황 폴링 간격 60초 → 5초로 단축

### DIFF
--- a/frontend/src/hooks/useProcessingStatus.ts
+++ b/frontend/src/hooks/useProcessingStatus.ts
@@ -1,4 +1,4 @@
-/* useProcessingStatus — 강의/주차 처리 상태를 60초 간격으로 폴링한다. */
+/* useProcessingStatus — 강의/주차 처리 상태를 5초 간격으로 폴링한다. */
 
 import { useEffect, useRef, useState } from 'react'
 import type { ProcessingStatusResponse } from '../types/models'
@@ -23,7 +23,7 @@ export function useProcessingStatus({
   lectureId,
   week,
   enabled,
-  interval = 60000,
+  interval = 5000,
   onComplete,
   onError,
 }: UseProcessingStatusOptions): UseProcessingStatusReturn {


### PR DESCRIPTION
## Summary
- 처리 진행상황 폴링 간격을 60초에서 5초로 변경
- 새로고침 없이 실시간으로 진행상황이 업데이트되도록 개선

## Test plan
- [ ] 강의 분석 시작 후 진행상황이 5초마다 자동 갱신되는지 확인
- [ ] 주차 가이드 생성 시 진행상황이 실시간 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)