### PR TITLE
fix: Phase 5 Formatter 출력 파일명 불일치 및 에러 묵살 수정

### DIFF
--- a/pipeline/preprocessor/wrapper.py
+++ b/pipeline/preprocessor/wrapper.py
@@ -135,10 +135,12 @@ def run_preprocess(
     logger.info("[Phase 5] Formatter 완료")
 
     # Phase 5 출력 파일을 lecture_id 기반 파일명으로 정규화
-    # (Formatter가 {date}_chunks_formatted.jsonl 로 저장하므로 {lecture_id}.jsonl 로 복사)
-    chunks_src = paths.DATA_PHASE5_FACTS / f"{date_part}_chunks_formatted.jsonl"
+    # Formatter는 chunks_path.stem 기반으로 파일을 저장하므로 phase3_file.stem 사용
+    chunks_src = paths.DATA_PHASE5_FACTS / f"{phase3_file.stem}_chunks_formatted.jsonl"
     chunks_dst = paths.DATA_PHASE5_FACTS / f"{lecture_id}.jsonl"
-    if chunks_src.exists() and chunks_src != chunks_dst:
+    if chunks_src != chunks_dst:
+        if not chunks_src.exists():
+            raise FileNotFoundError(f"Phase 5 Formatter 출력 없음: {chunks_src}")
         shutil.copy2(chunks_src, chunks_dst)
         logger.info("[Phase 5] 파일명 정규화: %s → %s", chunks_src.name, chunks_dst.name)
 


### PR DESCRIPTION
## 요약

- `wrapper.py`의 Phase 5 정규화 블록에서 `chunks_src` 경로 계산 오류 수정
- 파일 복사 실패 시 예외 없이 통과하던 버그 수정

## 원인

`05_formatter.py`의 `format_documents()`는 `chunks_path.stem` 기반으로 파일을 저장함:
- 입력: `phase3_file` (stem = `{lecture_id}`, 예: `2026-02-26_kdt-backendj-21th`)
- 출력: `{lecture_id}_chunks_formatted.jsonl`

하지만 `wrapper.py`는 `date_part`만 사용:
- 찾는 파일: `{date_part}_chunks_formatted.jsonl` (예: `2026-02-26_chunks_formatted.jsonl`)
- → 파일 없음 → `shutil.copy2` 건너뜀 → 예외 없이 `progress_callback(5, "done")` 호출
- → `{lecture_id}.jsonl` 미생성 상태로 EP 단계 진입 → `FileNotFoundError`

## 변경사항

- `chunks_src`를 `f"{phase3_file.stem}_chunks_formatted.jsonl"` 기반으로 수정
- 파일 미존재 시 `FileNotFoundError` 발생으로 Step 5 실패 명시화

## 테스트 계획

- [ ] 해당 강의로 재실행 시 Phase 5 → EP 순서대로 정상 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)