### PR TITLE
feat: 명제 추출·퀴즈 생성 단계별 세부 진행 상황 표시

### DIFF
--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -157,6 +157,7 @@ class ProcessingStep(BaseModel):
 
     name: str    # "영상 분석", "텍스트 추출", "AI 분석"
     status: Literal["pending", "running", "done"]
+    detail: str | None = None  # 세부 진행 정보 (예: "15/42 청크 | 명제 38개")
 
 
 class ProcessingStatusResponse(BaseModel):

--- a/frontend/src/components/ProcessingStatus.tsx
+++ b/frontend/src/components/ProcessingStatus.tsx
@@ -29,6 +29,7 @@ const DEFAULT_WEEK_STEPS: ProcessingStep[] = [
 interface MainStep {
   name: string
   status: 'pending' | 'running' | 'done'
+  detail?: string
   subSteps?: ProcessingStep[]
 }
 
@@ -65,6 +66,7 @@ function groupSteps(steps: ProcessingStep[]): MainStep[] {
         grouped.push({
           name: displayNames[idx],
           status: step.status as 'pending' | 'running' | 'done',
+          detail: step.detail,
         })
       } else {
         grouped.push({ name: displayNames[idx], status: 'pending' })
@@ -177,7 +179,7 @@ interface StepRowProps {
 }
 
 function StepRow({ step, index }: StepRowProps) {
-  const { name, status, subSteps } = step
+  const { name, status, detail, subSteps } = step
 
   return (
     <div className={`tml-processing-step tml-processing-step--${status} ${subSteps && subSteps.length > 0 && status !== 'pending' ? 'tml-processing-step--expanded' : ''}`}>
@@ -188,8 +190,13 @@ function StepRow({ step, index }: StepRowProps) {
 
       {/* 이름 + 플로우 + 진행 바 */}
       <div className="tml-processing-step__content">
-        <span className="tml-processing-step__name">{name}</span>
-        
+        <div className="tml-processing-step__name-row">
+          <span className="tml-processing-step__name">{name}</span>
+          {detail && status !== 'pending' && (
+            <span className="tml-processing-step__detail">{detail}</span>
+          )}
+        </div>
+
         {status === 'running' && subSteps === undefined && (
           <div className="tml-processing-step__track">
             <div className="tml-processing-step__fill tml-processing-fill--running" />
@@ -213,6 +220,9 @@ function StepRow({ step, index }: StepRowProps) {
                   {sub.status === 'done' ? '✓' : sub.status === 'running' ? '•' : '○'}
                 </span>
                 {subName}
+                {sub.detail && (
+                  <span className="tml-processing-substep__detail">{sub.detail}</span>
+                )}
               </div>
             )
           })}

--- a/frontend/src/hooks/useProcessingStatus.ts
+++ b/frontend/src/hooks/useProcessingStatus.ts
@@ -96,6 +96,16 @@ export function useProcessingStatus({
           console.log(`[폴링] ${target} — 응답: ${result.status}${percentLabel}`, steps, result.error_message ?? '')
         }
 
+        // 세부 진행 상황이 있는 step은 매 폴링마다 즉시 출력 (throttle 없음)
+        const phase4Step = steps.find((s) => s.name === 'Step 4: 명제 추출')
+        if (phase4Step?.status === 'running' && phase4Step?.detail) {
+          console.log(`[폴링] ${target} — [명제 추출] ${phase4Step.detail}`)
+        }
+        const quizStep = steps.find((s) => s.name === '퀴즈 생성')
+        if (quizStep?.status === 'running' && quizStep?.detail) {
+          console.log(`[폴링] ${target} — [퀴즈 생성] ${quizStep.detail}`)
+        }
+
         if (result.status === 'completed') {
           console.log(`[폴링] ${target} — 완료!`)
           onCompleteRef.current?.()

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2922,6 +2922,19 @@ body::after {
 .tml-processing-step--running .tml-processing-step__name { color: var(--tml-ink); }
 .tml-processing-step--done   .tml-processing-step__name { color: var(--tml-ink-secondary); }
 
+.tml-processing-step__name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tml-processing-step__detail {
+  font-size: 0.75rem;
+  color: var(--tml-ink-muted);
+  font-weight: 400;
+}
+
 .tml-processing-step__track {
   height: 4px;
   background: var(--tml-bg-overlay);
@@ -3257,6 +3270,13 @@ body::after {
   width: 16px;
   display: flex;
   justify-content: center;
+}
+
+.tml-processing-substep__detail {
+  margin-left: 6px;
+  font-size: 0.75rem;
+  color: var(--tml-ink-muted);
+  font-weight: 400;
 }
 
 /* R-1: 극소형 모바일(375px) padding 과대 방지 */

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -5,6 +5,7 @@ export type ProcessingStatus = 'idle' | 'processing' | 'completed' | 'error'
 export interface ProcessingStep {
   name: string // "영상 분석", "텍스트 추출", "AI 분석"
   status: 'pending' | 'running' | 'done'
+  detail?: string // 세부 진행 정보 (예: "15/42 청크 | 명제 38개")
 }
 
 // ===== 강의 카탈로그 =====

--- a/pipeline/preprocessor/04_extractor.py
+++ b/pipeline/preprocessor/04_extractor.py
@@ -149,7 +149,11 @@ class FactExtractor:
                 
         return []
 
-    def process_file(self, filepath: Path, output_dir: Path) -> dict[str, int]:
+    def process_file(self, filepath: Path, output_dir: Path, progress_callback=None) -> dict[str, int]:
+        """
+        Args:
+            progress_callback: Callable[[int, int, int], None] — (청크_완료수, 총_청크수, 명제_누적수)
+        """
         day = filepath.stem
         chunks = []
         with open(filepath, "r", encoding="utf-8") as f:
@@ -159,27 +163,28 @@ class FactExtractor:
                         chunks.append(json.loads(line))
                     except json.JSONDecodeError:
                         continue
-                        
+
         stats = {"input_chunks": len(chunks), "output_props": 0}
         results = []
         prop_counter = 1
-        
-        for chunk in tqdm(chunks, desc=f"  [지식 추출] {filepath.name}", leave=False):
+        total_chunks = len(chunks)
+
+        for i, chunk in enumerate(tqdm(chunks, desc=f"  [지식 추출] {filepath.name}", leave=False)):
             text = chunk.get("text", "")
             keywords = chunk.get("keywords", [])
-            
+
             props = self.extract_pattern(text)
-            
+
             if len(text) > 30 and (self.use_gemini or self.use_ollama):
                 llm_props = self.extract_llm(text, keywords)
                 for lp in llm_props:
                     lp["method"] = "llm"
                 props.extend(llm_props)
-                
+
             for prop in props:
                 c_candidates = list(set([prop.get("concept", "")] + keywords))
                 while "" in c_candidates: c_candidates.remove("")
-                
+
                 results.append({
                     "prop_id": f"{day}_P{prop_counter:04d}",
                     "chunk_id": chunk.get("chunk_id", ""),
@@ -193,7 +198,10 @@ class FactExtractor:
                     }
                 })
                 prop_counter += 1
-                
+
+            if progress_callback:
+                progress_callback(i + 1, total_chunks, len(results))
+
         stats["output_props"] = len(results)
         
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/pipeline/preprocessor/wrapper.py
+++ b/pipeline/preprocessor/wrapper.py
@@ -26,6 +26,7 @@ def run_preprocess(
     use_gemini_embed: bool = True,
     threshold: float = 0.40,
     progress_callback: Callable[[int, str], None] | None = None,
+    phase4_progress_callback: Callable[[int, int, int], None] | None = None,
 ) -> None:
     """단일 강의에 대해 Phase 1~5 전처리를 순차 실행.
 
@@ -114,7 +115,7 @@ def run_preprocess(
     FactExtractor = mod4.FactExtractor
 
     extractor = FactExtractor(use_gemini=True, use_ollama=False)
-    extractor.process_file(phase3_file, paths.DATA_PHASE4_PROPOSITIONS)
+    extractor.process_file(phase3_file, paths.DATA_PHASE4_PROPOSITIONS, progress_callback=phase4_progress_callback)
     logger.info("[Phase 4] FactExtractor 완료")
 
     phase4_file = _find_output_file(paths.DATA_PHASE4_PROPOSITIONS, lecture_id)

--- a/pipeline/quiz_generation/runner.py
+++ b/pipeline/quiz_generation/runner.py
@@ -8,6 +8,7 @@ Mode A 블록.
 
 import json
 from pathlib import Path
+from typing import Callable
 from uuid import uuid4
 
 from pipeline import paths
@@ -27,6 +28,7 @@ def run_quiz_generation(
     input_file: Path | None = None,
     output_file: Path | None = None,
     facts_file: Path | None = None,
+    detail_callback: Callable[[str], None] | None = None,
 ) -> None:
     """BlueprintDocument 전체 + Chunk 전체를 LLM에 넣어 퀴즈를 배치 생성.
 
@@ -71,9 +73,13 @@ def run_quiz_generation(
 
         # 단일 LLM 호출
         prompt = build_batch_prompt(blueprints, chunks, quiz_count=QUIZ_COUNT)
+        if detail_callback:
+            detail_callback(f"LLM 호출 중... (목표 {QUIZ_COUNT}개)")
         raw_quizzes = call_gemini_batch(prompt)
 
         # 검증
+        if detail_callback:
+            detail_callback(f"검증 중 (응답 {len(raw_quizzes)}개)")
         valid_quizzes, errors = validate_batch(raw_quizzes)
         for err in errors:
             print(f"  [INVALID] {err}")
@@ -91,6 +97,8 @@ def run_quiz_generation(
             for quiz in quizzes:
                 f.write(quiz.model_dump_json(ensure_ascii=False) + "\n")
 
+        if detail_callback:
+            detail_callback(f"퀴즈 {len(quizzes)}개 생성 완료")
         print(
             f"[OK]   {out_file.name} | "
             f"{len(quizzes)}/{len(raw_quizzes)} quizzes "


### PR DESCRIPTION
## 요약

- `ProcessingStep`에 `detail` 필드를 추가하여 단계별 세부 진행 정보를 실시간 전달
- **명제 추출 (Phase 4)**: 각 청크 처리 후 `N/M 청크 | 명제 X개` 형태로 업데이트
- **퀴즈 생성**: LLM 호출 → 검증 → 완료 시점마다 상태 문자열 업데이트
- 프론트엔드 UI에 step 이름 옆 detail 텍스트 표시 (서브스텝 포함)
- 콘솔: Phase 4·퀴즈 생성 진행 중 60초 throttle 없이 매 폴링마다 즉시 출력

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `app/schemas/models.py` | `ProcessingStep.detail` 필드 추가 |
| `pipeline/preprocessor/04_extractor.py` | `process_file`에 `progress_callback` 파라미터 추가 |
| `pipeline/preprocessor/wrapper.py` | `phase4_progress_callback` 파라미터 전달 |
| `app/api/routes.py` | `phase4_detail_callback`, `quiz_detail_callback` 연결 |
| `pipeline/quiz_generation/runner.py` | `detail_callback` 파라미터 추가, 3개 시점 호출 |
| `frontend/src/types/models.ts` | `ProcessingStep.detail?: string` 추가 |
| `frontend/src/components/ProcessingStatus.tsx` | step·서브스텝에 detail 표시 |
| `frontend/src/hooks/useProcessingStatus.ts` | Phase 4·퀴즈 생성 detail 즉시 콘솔 출력 |
| `frontend/src/index.css` | detail 스타일 추가 |

## 테스트 체크리스트

- [ ] 명제 추출 중 UI에 `N/M 청크 | 명제 X개` 표시 확인
- [ ] 퀴즈 생성 중 단계 메시지 순차 표시 확인
- [ ] 콘솔에 Phase 4·퀴즈 생성 detail 매 폴링 출력 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)