### PR TITLE
feat: 중단된 강의 재개 기능 (partial 상태 + 재개하기 버튼)

### DIFF
--- a/app/loaders/catalog.py
+++ b/app/loaders/catalog.py
@@ -11,7 +11,11 @@ import time
 from datetime import date
 from pathlib import Path
 
-from pipeline.paths import DATA_RAW, DATA_EP_CONCEPTS, DATA_EP_LEARNING_POINTS, DATA_QUIZZES_VALIDATED, DATA_PHASE1_SESSIONS, DATA_LEARNING_GUIDES
+from pipeline.paths import (
+    DATA_RAW, DATA_EP_CONCEPTS, DATA_EP_LEARNING_POINTS, DATA_QUIZZES_VALIDATED,
+    DATA_PHASE1_SESSIONS, DATA_PHASE2_SENTENCES, DATA_PHASE3_CHUNKS,
+    DATA_PHASE4_PROPOSITIONS, DATA_PHASE5_FACTS, DATA_LEARNING_GUIDES,
+)
 
 logger = logging.getLogger(__name__)
 from app.schemas.models import (
@@ -53,8 +57,17 @@ def _get_status(lecture_id: str) -> ProcessingStatus:
         and (DATA_QUIZZES_VALIDATED / f"{lecture_id}.jsonl").exists()
     ):
         return ProcessingStatus.completed
-    if (DATA_PHASE1_SESSIONS / f"{lecture_id}.jsonl").exists():
-        return ProcessingStatus.processing
+    # 중간 단계 파일이 하나라도 있으면 재개 가능 상태
+    _partial_paths = [
+        DATA_PHASE1_SESSIONS / f"{lecture_id}.jsonl",
+        DATA_PHASE2_SENTENCES / f"{lecture_id}.jsonl",
+        DATA_PHASE3_CHUNKS / f"{lecture_id}.jsonl",
+        DATA_PHASE4_PROPOSITIONS / f"{lecture_id}.jsonl",
+        DATA_PHASE5_FACTS / f"{lecture_id}.jsonl",
+        DATA_EP_CONCEPTS / f"{lecture_id}.jsonl",
+    ]
+    if any(p.exists() for p in _partial_paths):
+        return ProcessingStatus.partial
     return ProcessingStatus.idle
 
 

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -110,6 +110,7 @@ class ProcessingStatus(str, Enum):
     """파이프라인 처리 상태."""
 
     idle = "idle"
+    partial = "partial"       # 중간 단계까지 완료, 재개 가능
     processing = "processing"
     completed = "completed"
     error = "error"

--- a/frontend/src/components/ProcessingStatus.tsx
+++ b/frontend/src/components/ProcessingStatus.tsx
@@ -9,6 +9,7 @@ interface ProcessingStatusProps {
   week?: number
   onComplete: () => void
   onError?: (message: string) => void
+  onResume?: () => void  // 재개하기 버튼 클릭 시 호출
 }
 
 const DEFAULT_STEPS: ProcessingStep[] = [
@@ -119,19 +120,39 @@ export function ProcessingStatus({
   week,
   onComplete,
   onError,
+  onResume,
 }: ProcessingStatusProps) {
+  const [isResumable, setIsResumable] = useState(false)
+
   const { status, error } = useProcessingStatus({
     lectureId,
     week,
-    enabled: true,
+    enabled: !isResumable,
     onComplete,
     onError,
+    onPartial: () => setIsResumable(true),
   })
 
   const defaultSteps = week !== undefined ? DEFAULT_WEEK_STEPS : DEFAULT_STEPS
   const steps = (status?.steps && status.steps.length > 0) ? status.steps : defaultSteps
   const percent = status?.status === 'completed' ? 100 : calcPercent(steps)
   const elapsed = useElapsed(status?.started_at, status?.completed_at)
+
+  if (isResumable) {
+    return (
+      <div className="tml-processing-resumable">
+        <span className="tml-processing-resumable__msg">이전 작업 이어서 진행 가능</span>
+        {onResume && (
+          <button
+            className="tml-processing-resumable__btn"
+            onClick={() => { setIsResumable(false); onResume() }}
+          >
+            재개하기 →
+          </button>
+        )}
+      </div>
+    )
+  }
 
   if (error) {
     return (

--- a/frontend/src/hooks/useProcessingStatus.ts
+++ b/frontend/src/hooks/useProcessingStatus.ts
@@ -11,6 +11,7 @@ interface UseProcessingStatusOptions {
   interval?: number
   onComplete?: () => void
   onError?: (message: string) => void
+  onPartial?: () => void  // 재개 가능 상태 감지 시 호출
 }
 
 interface UseProcessingStatusReturn {
@@ -26,6 +27,7 @@ export function useProcessingStatus({
   interval = 5000,
   onComplete,
   onError,
+  onPartial,
 }: UseProcessingStatusOptions): UseProcessingStatusReturn {
   const [status, setStatus] = useState<ProcessingStatusResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -33,9 +35,11 @@ export function useProcessingStatus({
   // refs로 콜백을 감싸 stale closure 방지
   const onCompleteRef = useRef(onComplete)
   const onErrorRef = useRef(onError)
+  const onPartialRef = useRef(onPartial)
   useEffect(() => {
     onCompleteRef.current = onComplete
     onErrorRef.current = onError
+    onPartialRef.current = onPartial
   })
 
   useEffect(() => {
@@ -109,6 +113,11 @@ export function useProcessingStatus({
         if (result.status === 'completed') {
           console.log(`[폴링] ${target} — 완료!`)
           onCompleteRef.current?.()
+          return
+        }
+        if (result.status === 'partial' || result.status === 'idle') {
+          console.log(`[폴링] ${target} — 재개 가능 상태 감지`)
+          onPartialRef.current?.()
           return
         }
         if (result.status === 'error') {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3080,6 +3080,70 @@ body::after {
   line-height: 1.4;
 }
 
+/* 재개하기 UI (ProcessingStatus) */
+.tml-processing-resumable {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tml-processing-resumable__msg {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--tml-ink-muted);
+}
+
+.tml-processing-resumable__btn {
+  align-self: flex-start;
+  background: none;
+  border: 1.5px solid var(--tml-orange);
+  color: var(--tml-orange);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.tml-processing-resumable__btn:hover {
+  background: var(--tml-orange);
+  color: #fff;
+}
+
+/* 재개하기 UI (LectureCard partial) */
+.tml-lecture-card__resume {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tml-lecture-card__resume-msg {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--tml-ink-muted);
+}
+
+.tml-lecture-card__resume-btn {
+  align-self: flex-start;
+  background: none;
+  border: 1.5px solid var(--tml-orange);
+  color: var(--tml-orange);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.tml-lecture-card__resume-btn:hover {
+  background: var(--tml-orange);
+  color: #fff;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tml-processing-fill--running {
     animation: none;

--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -60,9 +60,10 @@ interface LectureCardProps {
   onProcessComplete: (lectureId: string) => void
   onProcessError: (lectureId: string) => void
   onRetry: (lectureId: string) => void
+  onResume: (lectureId: string) => void
 }
 
-function LectureCard({ lecture, isSelected, onToggleSelect, onViewResults, onProcessComplete, onProcessError, onRetry }: LectureCardProps) {
+function LectureCard({ lecture, isSelected, onToggleSelect, onViewResults, onProcessComplete, onProcessError, onRetry, onResume }: LectureCardProps) {
   const { lecture_id, date, day_of_week, week, course_name, status, result_summary } = lecture
   const gradient = getLectureThumbnailGradient(date, week)
 
@@ -119,7 +120,22 @@ function LectureCard({ lecture, isSelected, onToggleSelect, onViewResults, onPro
               lectureId={lecture_id}
               onComplete={() => onProcessComplete(lecture_id)}
               onError={() => onProcessError(lecture_id)}
+              onResume={() => onResume(lecture_id)}
             />
+          </div>
+        )}
+
+        {status === 'partial' && (
+          <div className="tml-lecture-card__footer">
+            <div className="tml-lecture-card__resume">
+              <span className="tml-lecture-card__resume-msg">이전 작업 이어서 진행 가능</span>
+              <button
+                className="tml-lecture-card__resume-btn"
+                onClick={(e) => { e.stopPropagation(); onResume(lecture_id) }}
+              >
+                재개하기 →
+              </button>
+            </div>
           </div>
         )}
 
@@ -278,6 +294,7 @@ interface WeekSectionProps {
   onProcessComplete: (lectureId: string) => void
   onProcessError: (lectureId: string) => void
   onRetry: (lectureId: string) => void
+  onResume: (lectureId: string) => void
   onProcessWeek: (week: number) => void
   onViewWeekResults: (week: number) => void
   onWeekProcessComplete: (week: number) => void
@@ -295,6 +312,7 @@ function WeekSection({
   onProcessComplete,
   onProcessError,
   onRetry,
+  onResume,
   onProcessWeek,
   onViewWeekResults,
   onWeekProcessComplete,
@@ -338,6 +356,7 @@ function WeekSection({
               onProcessComplete={onProcessComplete}
               onProcessError={onProcessError}
               onRetry={onRetry}
+              onResume={onResume}
             />
           )
         })}
@@ -518,8 +537,9 @@ export function LecturesPage() {
   // 서버 상태와 로컬 processingSet 동기화 (새로고침/뒤로가기 대응)
   useEffect(() => {
     const allLectures = weeks.flatMap((w) => w.lectures)
-    const serverProcessingIds = new Set(
-      allLectures.filter((l) => l.status === 'processing').map((l) => l.lecture_id),
+    // processing + partial 모두 폴링 대상 (partial은 폴링 후 재개 UI로 전환)
+    const serverActiveIds = new Set(
+      allLectures.filter((l) => l.status === 'processing' || l.status === 'partial').map((l) => l.lecture_id),
     )
     const serverCompletedIds = new Set(
       allLectures.filter((l) => l.status === 'completed').map((l) => l.lecture_id),
@@ -527,9 +547,7 @@ export function LecturesPage() {
 
     setProcessingLectures((prev) => {
       const next = new Set(prev)
-      // 서버에서 processing인 강의 추가
-      serverProcessingIds.forEach((id) => next.add(id))
-      // 서버에서 completed인 강의는 제거 (BUG-1: 뒤로가기 시 고착 방지)
+      serverActiveIds.forEach((id) => next.add(id))
       serverCompletedIds.forEach((id) => next.delete(id))
       return next
     })
@@ -597,6 +615,25 @@ export function LecturesPage() {
     try {
       await triggerLectureProcess(lectureId)
     } catch {
+      setProcessingLectures((prev) => {
+        const next = new Set(prev)
+        next.delete(lectureId)
+        return next
+      })
+    }
+  }, [])
+
+  const handleResume = useCallback(async (lectureId: string) => {
+    setProcessingLectures((prev) => new Set(prev).add(lectureId))
+    try {
+      await triggerLectureProcess(lectureId, false)
+    } catch (err: unknown) {
+      const status = (err as { status?: number }).status
+      if (status === 409) {
+        // 이미 처리 중 → 폴링이 이어받으므로 spinner 유지
+        return
+      }
+      // 그 외 에러 → spinner 해제
       setProcessingLectures((prev) => {
         const next = new Set(prev)
         next.delete(lectureId)
@@ -751,6 +788,7 @@ export function LecturesPage() {
                       onProcessComplete={handleProcessComplete}
                       onProcessError={handleProcessError}
                       onRetry={handleRetry}
+                      onResume={handleResume}
                       onProcessWeek={handleProcessWeek}
                       onViewWeekResults={(w) => navigate(`/weekly/${w}`)}
                       onWeekProcessComplete={handleWeekProcessComplete}

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -1,6 +1,6 @@
 // ===== 처리 상태 =====
 
-export type ProcessingStatus = 'idle' | 'processing' | 'completed' | 'error'
+export type ProcessingStatus = 'idle' | 'partial' | 'processing' | 'completed' | 'error'
 
 export interface ProcessingStep {
   name: string // "영상 분석", "텍스트 추출", "AI 분석"


### PR DESCRIPTION
## 요약

백엔드가 끊겼다 재시작되거나 중간에 처리가 중단됐을 때, 강의 카드에서 이전 작업을 감지하고 이어서 진행할 수 있는 UI를 제공한다.

## 동작 방식

| 상황 | 카드 표시 |
|------|-----------|
| 중간 단계 파일 존재 (서버 재시작 전) | 스피너 → 폴링 후 **재개하기** 버튼 전환 |
| 중간 단계 파일 존재 (서버 재시작 후) | **재개하기** 버튼 즉시 표시 |
| 재개하기 클릭 → 실제 작업 진행 중이면 | 스피너 유지 (409 처리) |
| 재개하기 클릭 → 서버 재시작 후 | 완료된 단계 건너뛰고 이어서 진행 |

## 변경 내용

- `ProcessingStatus` enum에 `partial` 추가
- `catalog._get_status`: Phase 1~5, EP 파일 존재 시 `partial` 반환
- `useProcessingStatus`: `onPartial` 콜백 — `partial`/`idle` 응답 시 호출, 폴링 중단
- `ProcessingStatus` 컴포넌트: 재개 가능 감지 시 재개하기 버튼 렌더링
- `LectureCard`: `partial` 상태 직접 처리 (재개하기 버튼)
- `LecturesPage`: `handleResume` 추가, `partial` 강의 폴링 대상 포함

🤖 Generated with [Claude Code](https://claude.ai/claude-code)