### PR TITLE
fix: 빈 파일 스킵 버그 수정 + README 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ frontend/.env.*.local
 ########################
 ERRORS.md
 tasks/
+docs/legacy/
+docs/tasks/
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,70 +1,62 @@
 # 알려주사자 (Tell Me Lion)
 
-강의 텍스트(STT 스크립트)에서 핵심 개념·학습 포인트·퀴즈·학습 가이드를 자동 생성해 수강생에게 제공하는 풀스택 교육 시스템.
+> 강의 녹화본을 선택하면, 핵심 개념 · 퀴즈 · 학습 가이드가 자동으로 만들어집니다.
+
+<!-- 📸 대시보드 전체 화면 캡처를 docs/images/dashboard.png로 저장 후 아래 주석 해제 -->
+<!-- ![대시보드](./docs/images/dashboard.png) -->
+
+**알려주사자**는 교육 서비스 업체와 수강생을 위한 AI 기반 학습 콘텐츠 자동 생성 시스템입니다. 파일 업로드 없이, 대시보드에서 강의를 선택하기만 하면 서버가 나머지를 처리합니다.
 
 ---
 
-## 빠른 시작
+## 주요 기능
 
-### 백엔드
+### Mode A — 단일 강의 분석
 
-```bash
-python -m uvicorn app.main:app --reload
-# API: http://localhost:8000  |  Docs: http://localhost:8000/docs
-```
+강의 스크립트 하나를 분석하여 **핵심 개념**, **학습 포인트**, **퀴즈**(객관식 · 주관식 · 빈칸 채우기 · 코드 실행)를 생성합니다.
 
-### 프론트엔드
+<!-- 📸 핵심 개념 + 퀴즈 카드가 보이는 화면을 docs/images/lecture-result.png로 저장 후 아래 주석 해제 -->
+<!-- ![단일 강의 결과](./docs/images/lecture-result.png) -->
 
-```bash
-cd frontend
-npm install
-npm run dev   # http://localhost:5173
-```
+### Mode B — 주차별 학습 가이드
 
-### 파이프라인
+한 주치 강의 전체를 종합 분석하여 **주차별 학습 가이드**와 **핵심 요약**을 자동 제작합니다.
 
-```bash
-# Mode A: 강의 1개 → 핵심 개념·학습 포인트·퀴즈
-python scripts/run_pipeline.py --mode a --input data/raw/lecture_01.txt
-
-# Mode B: 1주치 전체 → 주차별 학습 가이드·핵심 요약
-python scripts/run_pipeline.py --mode b --week 1
-
-# 블록 범위 지정
-python scripts/run_pipeline.py --mode a --from-block preproc --to-block ep
-
-# 전처리 Phase 범위 지정
-python scripts/run_pipeline.py --mode a --from-phase 1 --to-phase 3
-```
+<!-- 📸 주차별 학습 가이드 화면을 docs/images/weekly-guide.png로 저장 후 아래 주석 해제 -->
+<!-- ![주차별 학습 가이드](./docs/images/weekly-guide.png) -->
 
 ---
 
-## 구조
+## 시스템 아키텍처
 
 ```
-tell-me-lion/
-├── app/                # FastAPI 백엔드
-├── pipeline/           # 데이터 처리 파이프라인
-│   ├── preprocessor/   # Phase 1~5: STT → 구조화 팩트
-│   ├── ep/             # 핵심 개념·학습 포인트 추출
-│   ├── blueprint/      # 퀴즈 설계
-│   ├── quiz_generation/
-│   ├── qa_validation/
-│   └── guides/
-├── frontend/           # React SPA
-├── scripts/            # run_pipeline.py 등
-├── config/             # 퀴즈 규칙, RAG 설정
-└── data/               # 파이프라인 입출력 (git 제외)
+┌─────────────────┐       API        ┌─────────────────┐
+│    Frontend      │ ◄──────────────► │    Backend       │
+│  React · Vite    │                  │    FastAPI       │
+│  Vercel 배포     │                  │    EC2 배포      │
+└─────────────────┘                  └────────┬────────┘
+                                              │
+                                     ┌────────▼────────┐
+                                     │    Pipeline      │
+                                     │  전처리 → 추출   │
+                                     │  → 퀴즈 생성     │
+                                     │  → 품질 검증     │
+                                     │  → 가이드 생성   │
+                                     └─────────────────┘
+                                              │
+                                        Gemini API
 ```
 
----
+### 파이프라인 상세
 
-## 두 가지 사용 모드
-
-| 입력 | 출력 |
+| 단계 | 설명 |
 |------|------|
-| 강의 스크립트 1개 (`.txt`) | 핵심 개념, 학습 포인트, 퀴즈 |
-| 1주치 강의 스크립트 전체 | 주차별 학습 가이드, 핵심 요약 |
+| **Preprocessor** | STT 텍스트 정제 → 문단 분할 → 청킹 → 정보 추출 → 구조화 |
+| **EP (Extraction)** | TF-IDF 기반 핵심 개념 · 학습 포인트 추출 |
+| **Blueprint** | 퀴즈 유형 설계, 팩트 선별, 선택지 풀 구성 |
+| **Quiz Generation** | Gemini API를 활용한 퀴즈 생성 |
+| **QA Validation** | 난이도 · 변별력 · 중복 · 근거 검증 |
+| **Guides** | 주차별 학습 가이드 종합 생성 |
 
 ---
 
@@ -72,17 +64,100 @@ tell-me-lion/
 
 | 영역 | 기술 |
 |------|------|
-| 백엔드 | Python 3.10+, FastAPI, Uvicorn, Pydantic v2 |
-| 프론트엔드 | React 19, TypeScript 5.9, Vite 8, Tailwind CSS 4 |
-| AI·파이프라인 | Google Gemini API, KiwiPiePy, KR-SBERT, scikit-learn |
-| 실행 | 로컬 환경 (팀원 PC에서 직접 실행) |
+| **프론트엔드** | React 19, TypeScript 5.9, Vite 8, Tailwind CSS 4, Monaco Editor |
+| **백엔드** | Python 3.10+, FastAPI, Uvicorn, Pydantic v2 |
+| **AI · NLP** | Google Gemini API, KiwiPiePy (형태소 분석), scikit-learn (TF-IDF) |
+| **배포** | Vercel (프론트), AWS EC2 + Docker Compose (백엔드), GitHub Actions CI/CD |
+
+---
+
+## 시작하기
+
+### 사전 요구사항
+
+- Node.js 18+
+- Python 3.10+
+- Google Gemini API 키
+
+### 프론트엔드
+
+```bash
+cd frontend
+npm install
+npm run dev          # http://localhost:5173
+```
+
+### 백엔드
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload   # http://localhost:8000
+```
+
+### 환경 변수
+
+```bash
+# frontend/.env.local
+VITE_API_URL=http://localhost:8000
+```
+
+### 파이프라인 실행
+
+```bash
+# Mode A: 강의 1개 분석
+python scripts/run_pipeline.py --mode a --input data/raw/lecture_01.txt
+
+# Mode B: 1주치 전체 분석
+python scripts/run_pipeline.py --mode b --week 1
+```
+
+---
+
+## 프로젝트 구조
+
+```
+tell-me-lion/
+├── frontend/             # React SPA
+│   └── src/
+│       ├── pages/        # Dashboard, LecturesPage, LectureResult, WeeklyResult, QuizPage
+│       ├── components/   # ConceptCard, QuizCard, CodeEditor, ProcessingStatus 등
+│       ├── services/     # API 호출 (api.ts)
+│       ├── hooks/        # useProcessingStatus, useWeeks 등
+│       └── types/        # TypeScript 인터페이스
+├── app/                  # FastAPI 백엔드
+│   ├── api/routes.py     # API 엔드포인트
+│   ├── schemas/models.py # Pydantic 모델
+│   └── loaders/          # 데이터 로더
+├── pipeline/             # AI 처리 파이프라인
+│   ├── preprocessor/     # Phase 1~5: STT → 구조화 팩트
+│   ├── ep/               # 핵심 개념 · 학습 포인트 추출
+│   ├── blueprint/        # 퀴즈 설계
+│   ├── quiz_generation/  # 퀴즈 생성
+│   ├── qa_validation/    # 품질 검증
+│   └── guides/           # 학습 가이드 생성
+├── config/               # 퀴즈 규칙, RAG 설정
+├── scripts/              # 파이프라인 실행 스크립트
+└── data/                 # 파이프라인 입출력 데이터
+```
+
+---
+
+## 배포
+
+| 레이어 | 플랫폼 | 주소 | 방식 |
+|--------|--------|------|------|
+| 프론트엔드 | Vercel | [wonder-girls.vercel.app](https://wonder-girls.vercel.app) | `main` push 시 자동 배포 |
+| 백엔드 | AWS EC2 | (내부 IP) | GitHub Actions → Docker Compose |
+
+PR을 `main`에 머지하면 양쪽 모두 자동으로 배포됩니다.
 
 ---
 
 ## 문서
 
-- [`CLAUDE.md`](./CLAUDE.md) — 아키텍처, 코딩 규칙, 워크플로우
-- [`DESIGN.md`](./DESIGN.md) — 프론트엔드 디자인 가이드
-- [`DEPLOY.md`](./DEPLOY.md) — 배포 플랜 및 설정
-- [`ERRORS.md`](./ERRORS.md) — 오류 기록
-- [`docs/preprocessing-flow.md`](./docs/preprocessing-flow.md) — 전처리 데이터 플로우
+| 문서 | 내용 |
+|------|------|
+| [DESIGN.md](./DESIGN.md) | 프론트엔드 디자인 가이드 (색상 · 타이포 · 컴포넌트) |
+| [DEPLOY.md](./DEPLOY.md) | 배포 설정 상세 |
+| [docs/preprocessing-flow.md](./docs/preprocessing-flow.md) | 전처리 데이터 플로우 |
+| [PROJECT_GOALS.md](./PROJECT_GOALS.md) | 프로젝트 목표 · 평가 기준 |

--- a/pipeline/preprocessor/wrapper.py
+++ b/pipeline/preprocessor/wrapper.py
@@ -182,20 +182,25 @@ def _find_output_file(directory: Path, lecture_id: str) -> Path | None:
     파일명 규칙:
     - 정확히 일치: {lecture_id}.jsonl
     - 날짜 기반: {date}.jsonl (lecture_id에서 date 부분 추출)
+
+    빈 파일(0바이트 또는 0줄)은 존재하지 않는 것으로 간주한다.
     """
+    def _is_valid(p: Path) -> bool:
+        return p.exists() and p.stat().st_size > 0
+
     # 정확한 파일명 매칭
     exact = directory / f"{lecture_id}.jsonl"
-    if exact.exists():
+    if _is_valid(exact):
         return exact
 
     # 날짜 기반 매칭 (lecture_id = "2026-02-11_kdt-backend-21th" → date = "2026-02-11")
     date_part = lecture_id.split("_")[0] if "_" in lecture_id else lecture_id
     date_file = directory / f"{date_part}.jsonl"
-    if date_file.exists():
+    if _is_valid(date_file):
         return date_file
 
     # 부분 매칭 (lecture_id가 포함된 파일)
-    candidates = list(directory.glob(f"*{date_part}*.jsonl"))
+    candidates = [p for p in directory.glob(f"*{date_part}*.jsonl") if _is_valid(p)]
     if candidates:
         return candidates[0]
 


### PR DESCRIPTION
## Summary

- `_find_output_file`에서 0바이트 파일을 존재하는 것으로 간주해 Phase를 스킵하던 버그 수정
- Phase 1 출력이 빈 파일이면 Phase 1부터 재실행되도록 `_is_valid` 검사 추가
- README.md 최신화 및 `.gitignore`에 `docs/tasks/`, `docs/legacy/` 추가

## 배경

`2026-02-02_kdt-backendj-21th` 강의 처리 시 Phase 1 출력이 0줄짜리 빈 파일로 생성됨.
기존 코드는 파일 존재 여부만 확인해 Phase 1~2를 스킵 → Phase 3 입력 없음 → `Phase 3 출력 없음` 에러 발생.

## Test plan

- [ ] 빈 phase1/phase2 파일이 존재하는 강의 재처리 시 Phase 1부터 재실행되는지 확인
- [ ] 정상 파일이 있는 강의는 기존처럼 해당 Phase 스킵되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)