### PR TITLE
feat: 명제 추출 단계 진행률 표시 (단락 수)

### DIFF
--- a/frontend/src/components/ProcessingStatus.tsx
+++ b/frontend/src/components/ProcessingStatus.tsx
@@ -240,7 +240,10 @@ function StepRow({ step, index }: StepRowProps) {
                 <span className="tml-processing-substep__icon">
                   {sub.status === 'done' ? '✓' : sub.status === 'running' ? '•' : '○'}
                 </span>
-                {subName}
+                <span className="tml-processing-substep__name">{subName}</span>
+                {sub.detail && sub.status === 'running' && (
+                  <span className="tml-processing-substep__detail">{sub.detail.split(' | ')[0]}</span>
+                )}
               </div>
             )
           })}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3376,13 +3376,11 @@ body::after {
 }
 
 .tml-processing-substep__detail {
-  display: block;
-  margin-left: 20px; /* icon width 맞춤 */
-  margin-top: 1px;
+  flex-basis: 100%;
+  margin-left: 22px; /* icon width + gap 맞춤 */
   font-size: 0.725rem;
   color: var(--tml-ink-muted);
   font-weight: 400;
-  white-space: normal;
 }
 
 /* R-1: 극소형 모바일(375px) padding 과대 방지 */


### PR DESCRIPTION
## Summary

- 전처리 서브스텝에 `detail` 필드 렌더링 추가 — 명제 추출 진행 중 단락 수 표시
- 명제 수(`| 명제 N개`)는 UI에서 제외, 콘솔 로그에만 출력
- `flex-basis: 100%`로 detail을 이름 아래 줄로 내려 텍스트 잘림 방지

**표시 예시:**
```
• 명제 추출
  12/48 단락
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)