### PR TITLE
fix: 파이프라인 안정성 종합 개선

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -46,6 +46,9 @@ from app.state import (
 
 router = APIRouter(prefix="/api", tags=["산출물"])
 
+# 강의 파이프라인 동시 실행 제한 (Gemini API rate limit 보호)
+_lecture_semaphore = asyncio.Semaphore(1)
+
 
 def _write_jsonl(path, data: list[dict]) -> None:
     """JSONL 파일 atomic write. 임시 파일에 쓴 후 os.replace()로 교체."""
@@ -144,7 +147,16 @@ async def _run_lecture_pipeline(lecture_id: str) -> None:
     """Mode A: 강의 파이프라인 실행 (전처리 → EP → Blueprint → Quiz).
 
     각 단계 출력 파일이 이미 존재하면 해당 단계를 건너뛴다.
+    Semaphore(1)로 동시 실행을 1개로 제한한다 (Gemini API rate limit 보호).
     """
+    from pipeline.paths import DATA_PHASE1_SESSIONS, DATA_BLUEPRINTS
+
+    async with _lecture_semaphore:
+        await _run_lecture_pipeline_inner(lecture_id)
+
+
+async def _run_lecture_pipeline_inner(lecture_id: str) -> None:
+    """실제 파이프라인 실행 (Semaphore 내부에서 호출)."""
     from pipeline.paths import DATA_PHASE1_SESSIONS, DATA_BLUEPRINTS
 
     job = await get_lecture_job(lecture_id)
@@ -255,14 +267,25 @@ def _exec_preprocess(
     )
 
 
+def _find_file(directory, lecture_id: str):
+    """디렉터리에서 lecture_id에 매칭되는 JSONL 파일을 찾는다 (정확 → 부분 매칭)."""
+    from pathlib import Path
+    exact = directory / f"{lecture_id}.jsonl"
+    if exact.exists() and exact.stat().st_size > 0:
+        return exact
+    date_part = lecture_id.split("_")[0] if "_" in lecture_id else lecture_id
+    candidates = [p for p in directory.glob(f"*{date_part}*.jsonl") if p.stat().st_size > 0]
+    return candidates[0] if candidates else None
+
+
 def _exec_ep(lecture_id: str) -> None:
     """EP 실행 (개념 + 학습 포인트 추출)."""
     from pipeline.ep.runner import run_ep
     from pipeline.paths import DATA_PHASE5_FACTS
 
-    phase5_file = DATA_PHASE5_FACTS / f"{lecture_id}.jsonl"
-    if not phase5_file.exists():
-        raise FileNotFoundError(f"전처리 출력 파일 없음: {phase5_file}")
+    phase5_file = _find_file(DATA_PHASE5_FACTS, lecture_id)
+    if not phase5_file:
+        raise FileNotFoundError(f"전처리 출력 파일 없음: {DATA_PHASE5_FACTS / f'{lecture_id}.jsonl'}")
     run_ep(input_file=phase5_file, out_dir=DATA_EP_CONCEPTS)
 
 
@@ -270,9 +293,9 @@ def _exec_blueprint(lecture_id: str) -> None:
     """Blueprint 실행."""
     from pipeline.blueprint.runner import run_blueprint
 
-    ep_file = DATA_EP_CONCEPTS / f"{lecture_id}.jsonl"
-    if not ep_file.exists():
-        raise FileNotFoundError(f"EP 출력 파일 없음: {ep_file}")
+    ep_file = _find_file(DATA_EP_CONCEPTS, lecture_id)
+    if not ep_file:
+        raise FileNotFoundError(f"EP 출력 파일 없음: {DATA_EP_CONCEPTS / f'{lecture_id}.jsonl'}")
     run_blueprint(input_file=ep_file)
 
 
@@ -284,9 +307,9 @@ def _exec_quiz_generation(
     from pipeline.quiz_generation.runner import run_quiz_generation
     from pipeline.paths import DATA_BLUEPRINTS, DATA_QUIZZES_RAW
 
-    bp_file = DATA_BLUEPRINTS / f"{lecture_id}.jsonl"
-    if not bp_file.exists():
-        raise FileNotFoundError(f"Blueprint 출력 파일 없음: {bp_file}")
+    bp_file = _find_file(DATA_BLUEPRINTS, lecture_id)
+    if not bp_file:
+        raise FileNotFoundError(f"Blueprint 출력 파일 없음: {DATA_BLUEPRINTS / f'{lecture_id}.jsonl'}")
     run_quiz_generation(
         input_file=bp_file,
         output_file=DATA_QUIZZES_RAW / f"{lecture_id}.jsonl",

--- a/app/loaders/catalog.py
+++ b/app/loaders/catalog.py
@@ -49,24 +49,34 @@ def _calculate_week(lecture_date: date, first_date: date) -> int:
     return (delta_days // 7) + 1
 
 
+def _has_output(directory: Path, lecture_id: str) -> bool:
+    """디렉터리에서 lecture_id에 매칭되는 비어있지 않은 JSONL 파일이 있는지 확인.
+    정확한 이름({lecture_id}.jsonl) 또는 부분 매칭(*{date_part}*.jsonl)을 시도한다.
+    """
+    exact = directory / f"{lecture_id}.jsonl"
+    if exact.exists() and exact.stat().st_size > 0:
+        return True
+    date_part = lecture_id.split("_")[0] if "_" in lecture_id else lecture_id
+    return any(
+        p.stat().st_size > 0
+        for p in directory.glob(f"*{date_part}*.jsonl")
+    )
+
+
 def _get_status(lecture_id: str) -> ProcessingStatus:
     """파이프라인 출력 디렉터리를 확인해 처리 상태를 판별."""
     if (
-        (DATA_EP_CONCEPTS / f"{lecture_id}.jsonl").exists()
-        and (DATA_EP_LEARNING_POINTS / f"{lecture_id}.jsonl").exists()
-        and (DATA_QUIZZES_VALIDATED / f"{lecture_id}.jsonl").exists()
+        _has_output(DATA_EP_CONCEPTS, lecture_id)
+        and _has_output(DATA_EP_LEARNING_POINTS, lecture_id)
+        and _has_output(DATA_QUIZZES_VALIDATED, lecture_id)
     ):
         return ProcessingStatus.completed
     # 중간 단계 파일이 하나라도 있으면 재개 가능 상태
-    _partial_paths = [
-        DATA_PHASE1_SESSIONS / f"{lecture_id}.jsonl",
-        DATA_PHASE2_SENTENCES / f"{lecture_id}.jsonl",
-        DATA_PHASE3_CHUNKS / f"{lecture_id}.jsonl",
-        DATA_PHASE4_PROPOSITIONS / f"{lecture_id}.jsonl",
-        DATA_PHASE5_FACTS / f"{lecture_id}.jsonl",
-        DATA_EP_CONCEPTS / f"{lecture_id}.jsonl",
+    _partial_dirs = [
+        DATA_PHASE1_SESSIONS, DATA_PHASE2_SENTENCES, DATA_PHASE3_CHUNKS,
+        DATA_PHASE4_PROPOSITIONS, DATA_PHASE5_FACTS, DATA_EP_CONCEPTS,
     ]
-    if any(p.exists() for p in _partial_paths):
+    if any(_has_output(d, lecture_id) for d in _partial_dirs):
         return ProcessingStatus.partial
     return ProcessingStatus.idle
 

--- a/app/main.py
+++ b/app/main.py
@@ -39,18 +39,30 @@ def _cleanup_orphaned_markers() -> None:
         DATA_EP_CONCEPTS, DATA_EP_LEARNING_POINTS, DATA_BLUEPRINTS, DATA_QUIZZES_RAW, DATA_QUIZZES_VALIDATED,
     ]
 
+    def _has_any(directory, lid):
+        """디렉터리에서 lecture_id에 매칭되는 파일이 있는지 부분 매칭으로 확인."""
+        exact = directory / f"{lid}.jsonl"
+        if exact.exists() and exact.stat().st_size > 0:
+            return True
+        date_part = lid.split("_")[0] if "_" in lid else lid
+        return any(p.stat().st_size > 0 for p in directory.glob(f"*{date_part}*.jsonl"))
+
     removed = 0
     if not DATA_PHASE1_SESSIONS.exists():
         return
     for marker in DATA_PHASE1_SESSIONS.glob("*.jsonl"):
         lecture_id = marker.stem
         if (
-            (DATA_EP_CONCEPTS / f"{lecture_id}.jsonl").exists()
-            and (DATA_EP_LEARNING_POINTS / f"{lecture_id}.jsonl").exists()
-            and (DATA_QUIZZES_VALIDATED / f"{lecture_id}.jsonl").exists()
+            _has_any(DATA_EP_CONCEPTS, lecture_id)
+            and _has_any(DATA_EP_LEARNING_POINTS, lecture_id)
+            and _has_any(DATA_QUIZZES_VALIDATED, lecture_id)
         ):
             continue  # 완료된 강의는 건드리지 않음
+        # phase5까지 도달한 파일이 있으면 중간 단계(phase1~3)만 정리, phase5 보존
+        has_phase5 = _has_any(DATA_PHASE5_FACTS, lecture_id)
         for d in _INTERMEDIATE_DIRS:
+            if has_phase5 and d in (DATA_PHASE5_FACTS, DATA_EP_CONCEPTS, DATA_EP_LEARNING_POINTS, DATA_BLUEPRINTS):
+                continue  # Phase 5 이후 파일은 보존
             f = d / f"{lecture_id}.jsonl"
             if f.exists():
                 f.unlink()

--- a/pipeline/preprocessor/03_chunker.py
+++ b/pipeline/preprocessor/03_chunker.py
@@ -48,36 +48,57 @@ class SemanticChunker:
             self.model = SentenceTransformer(model_name)
 
     def _get_embeddings(self, texts: list[str]) -> list[list[float]]:
-        """Gemini API 또는 로컬 SBERT를 통해 임베딩 벡터 목록을 반환"""
-        if self.use_gemini_embed:
-            # Gemini Embedding API 한도 보호를 위해 청크 요청 (최대 100개)
-            all_embeddings = []
-            try:
-                for i in range(0, len(texts), 90):
-                    batch_texts = texts[i:i+90]
-                    response = self.gemini_client.models.embed_content(
-                        model=self.embed_model,
-                        contents=batch_texts
-                    )
-                    time.sleep(0.5) # API Rate Limit 회피
-                    
-                    # 만약 embeddings가 리스트라면 extend
-                    if hasattr(response, 'embeddings'):
-                        all_embeddings.extend([emb.values for emb in response.embeddings])
-                    else:
-                        # 예외적으로 단일 결과일 때
-                        all_embeddings.append(response.embeddings.values)
+        """Gemini API 또는 로컬 SBERT를 통해 임베딩 벡터 목록을 반환.
 
-                # 만약 어떤 이유로든 반환 길이가 다르면 패딩처리
-                if len(all_embeddings) != len(texts):
-                    print(f"[Warning] Mismatched embedding length. texts: {len(texts)}, embeds: {len(all_embeddings)}")
-                    return [[0.0]*768 for _ in texts]
-                    
-                return all_embeddings
-            except Exception as e:
-                print(f"[Gemini Embed Error] API 호출 실패: {e}")
-                # 오류 발생 시 임시로 0 벡터 반환 (실패 방지)
-                return [[0.0]*768 for _ in texts]
+        API 429 (rate limit) 발생 시 retryDelay를 준수하여 최대 3회 재시도.
+        재시도 실패 시 RuntimeError를 발생시킨다 (0 벡터 폴백은 청킹을 무력화하므로 금지).
+        """
+        if self.use_gemini_embed:
+            import re as _re
+            all_embeddings = []
+            max_retries = 3
+            for i in range(0, len(texts), 90):
+                batch_texts = texts[i:i+90]
+                last_error = None
+                for attempt in range(max_retries + 1):
+                    try:
+                        response = self.gemini_client.models.embed_content(
+                            model=self.embed_model,
+                            contents=batch_texts
+                        )
+                        time.sleep(0.5)
+                        if hasattr(response, 'embeddings'):
+                            all_embeddings.extend([emb.values for emb in response.embeddings])
+                        else:
+                            all_embeddings.append(response.embeddings.values)
+                        break  # 성공 시 다음 배치로
+                    except Exception as e:
+                        last_error = e
+                        err_str = str(e)
+                        # 429 rate limit: retryDelay 파싱 후 대기
+                        if "429" in err_str or "RESOURCE_EXHAUSTED" in err_str:
+                            delay_match = _re.search(r"retry(?:Delay)?['\"]?:\s*['\"]?(\d+\.?\d*)", err_str)
+                            wait_sec = float(delay_match.group(1)) + 1.0 if delay_match else 15.0 * (attempt + 1)
+                            print(f"[Gemini Embed] 429 rate limit — {wait_sec:.0f}초 대기 후 재시도 ({attempt+1}/{max_retries})")
+                            time.sleep(wait_sec)
+                        elif "503" in err_str or "UNAVAILABLE" in err_str:
+                            wait_sec = 10.0 * (2 ** attempt)
+                            print(f"[Gemini Embed] 503 서비스 불가 — {wait_sec:.0f}초 대기 후 재시도 ({attempt+1}/{max_retries})")
+                            time.sleep(wait_sec)
+                        else:
+                            # 재시도 불가능한 에러
+                            raise RuntimeError(f"임베딩 API 호출 실패 (재시도 불가): {e}") from e
+                else:
+                    # 재시도 모두 소진
+                    raise RuntimeError(
+                        f"임베딩 API 호출 {max_retries}회 재시도 후에도 실패: {last_error}"
+                    )
+
+            if len(all_embeddings) != len(texts):
+                raise RuntimeError(
+                    f"임베딩 결과 길이 불일치: texts={len(texts)}, embeds={len(all_embeddings)}"
+                )
+            return all_embeddings
         else:
             return self.model.encode(texts).tolist()
 

--- a/pipeline/preprocessor/04_extractor.py
+++ b/pipeline/preprocessor/04_extractor.py
@@ -126,26 +126,37 @@ class FactExtractor:
                 return []
 
         elif self.use_gemini and self.client:
-            try:
-                response = self.client.models.generate_content(
-                    model=self.model_name,
-                    contents=prompt,
-                    config=self.gen_config
-                )
-                time.sleep(2)
+            max_retries = 3
+            for attempt in range(max_retries + 1):
+                try:
+                    response = self.client.models.generate_content(
+                        model=self.model_name,
+                        contents=prompt,
+                        config=self.gen_config
+                    )
+                    time.sleep(2)
 
-                res_text = response.text.strip()
-                if res_text.startswith("```json"):
-                    res_text = res_text[7:-3]
-                elif res_text.startswith("```"):
-                    res_text = res_text[3:-3]
+                    res_text = response.text.strip()
+                    if res_text.startswith("```json"):
+                        res_text = res_text[7:-3]
+                    elif res_text.startswith("```"):
+                        res_text = res_text[3:-3]
 
-                parsed = json.loads(res_text.strip())
-                return parsed if isinstance(parsed, list) else []
-            except Exception as e:
-                print(f"[Gemini Error] 추출 실패: {e}")
-                time.sleep(4)
-                return []
+                    parsed = json.loads(res_text.strip())
+                    return parsed if isinstance(parsed, list) else []
+                except json.JSONDecodeError:
+                    return []
+                except Exception as e:
+                    err_str = str(e)
+                    if attempt < max_retries and ("429" in err_str or "503" in err_str or "RESOURCE_EXHAUSTED" in err_str or "UNAVAILABLE" in err_str):
+                        wait_sec = 10.0 * (2 ** attempt)
+                        print(f"[Gemini] 추출 재시도 ({attempt+1}/{max_retries}) — {wait_sec:.0f}초 대기: {err_str[:80]}")
+                        time.sleep(wait_sec)
+                    else:
+                        print(f"[Gemini Error] 추출 실패: {e}")
+                        time.sleep(4)
+                        return []
+            return []
                 
         return []
 

--- a/pipeline/preprocessor/wrapper.py
+++ b/pipeline/preprocessor/wrapper.py
@@ -150,6 +150,12 @@ def run_preprocess(
     phase5_file = _find_output_file(paths.DATA_PHASE5_FACTS, lecture_id)
     if phase5_file:
         logger.info("[SKIP] Phase 5 — 출력 파일 존재: %s", phase5_file)
+        # SKIP해도 정규화된 파일명이 없으면 복사 수행 (EP 등 후속 단계가 {lecture_id}.jsonl을 기대)
+        canonical = paths.DATA_PHASE5_FACTS / f"{lecture_id}.jsonl"
+        if not canonical.exists() and phase5_file != canonical:
+            import shutil
+            shutil.copy2(phase5_file, canonical)
+            logger.info("[Phase 5] 정규화 복사: %s → %s", phase5_file.name, canonical.name)
         if progress_callback:
             progress_callback(5, "done")
     else:

--- a/pipeline/quiz_generation/quiz_generator.py
+++ b/pipeline/quiz_generation/quiz_generator.py
@@ -29,15 +29,20 @@ def _get_client() -> genai.Client:
 def call_gemini_batch(prompt: str) -> list[dict]:
     """Gemini API를 호출하고 JSON 배열 응답을 파싱해 반환.
 
+    429/503 에러 시 최대 3회 지수 백오프 재시도.
+
     Args:
         prompt: 배치 퀴즈 생성 프롬프트.
 
     Returns:
-        파싱된 퀴즈 dict 목록. 파싱 실패 시 빈 리스트.
+        파싱된 퀴즈 dict 목록.
 
     Raises:
         RuntimeError: API 키 없음 또는 API 호출 실패.
+        ValueError: JSON 파싱 실패.
     """
+    import time
+
     client = _get_client()
     gen_config = types.GenerateContentConfig(
         system_instruction=SYSTEM_INSTRUCTION,
@@ -47,11 +52,27 @@ def call_gemini_batch(prompt: str) -> list[dict]:
         max_output_tokens=8192,
     )
 
-    response = client.models.generate_content(
-        model=MODEL_NAME,
-        contents=prompt,
-        config=gen_config,
-    )
+    max_retries = 3
+    last_error = None
+    for attempt in range(max_retries + 1):
+        try:
+            response = client.models.generate_content(
+                model=MODEL_NAME,
+                contents=prompt,
+                config=gen_config,
+            )
+            break
+        except Exception as e:
+            last_error = e
+            err_str = str(e)
+            if attempt < max_retries and ("429" in err_str or "503" in err_str or "RESOURCE_EXHAUSTED" in err_str or "UNAVAILABLE" in err_str):
+                wait_sec = 15.0 * (2 ** attempt)
+                print(f"[Quiz Gen] Gemini API 재시도 ({attempt+1}/{max_retries}) — {wait_sec:.0f}초 대기")
+                time.sleep(wait_sec)
+            else:
+                raise RuntimeError(f"Gemini API 호출 실패: {e}") from e
+    else:
+        raise RuntimeError(f"Gemini API {max_retries}회 재시도 후에도 실패: {last_error}")
 
     raw_text = response.text.strip()
 


### PR DESCRIPTION
## Summary
- EC2 로그 분석으로 확인된 파이프라인 중간 멈춤/실패의 근본 원인 7개를 수정
- **Semaphore(1)**: 강의 동시 처리 1개 제한 → Gemini API rate limit 보호
- **임베딩 재시도**: 429/503 시 retryDelay 기반 최대 3회 재시도, 실패 시 0벡터 대신 에러 발생
- **Phase 4/Quiz 재시도**: Gemini API 에러 시 지수 백오프 재시도
- **파일명 정규화**: Phase 5 `*_chunks_formatted.jsonl` → `{lecture_id}.jsonl` 자동 복사
- **부분 매칭**: routes.py, catalog.py, main.py에서 파일명 부분 매칭 지원

## 근본 원인 분석
| 문제 | 원인 | 영향 |
|------|------|------|
| 429 rate limit | 2개 강의 동시 처리 | Phase 3 임베딩 실패 → 0벡터 폴백 |
| 청크 2,457개 | 0벡터로 코사인 유사도 깨짐 | 정상 ~150개 vs 비정상 ~2,500개 |
| Phase 4 ~4시간 | 2,457회 API 호출 | 정상 ~15분 → 비정상 4시간+ |
| EP 실패 | `_chunks_formatted.jsonl` ≠ `{lecture_id}.jsonl` | Phase 5 이후 전부 실패 |

## EC2 추가 작업 (완료)
- [x] 2GB swap 파일 생성
- [x] 망가진 Phase 3 데이터 삭제
- [x] Phase 5/EP 파일명 정규화

## Test plan
- [ ] EC2 배포 후 단일 강의 분석 정상 완료 확인 (Phase 1~퀴즈)
- [ ] Phase 3 청크 수 확인 (~100-200 범위)
- [ ] 2개 강의 연속 분석 시 Semaphore로 순차 처리 확인
- [ ] 서버 재시작 후 고아 파일 정리가 Phase 5 보존하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)