### PR TITLE
fix: 퀴즈 생성 JSON 파싱 실패 시 재시도 및 자동 보정

### DIFF
--- a/pipeline/quiz_generation/quiz_generator.py
+++ b/pipeline/quiz_generation/quiz_generator.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import re
+import time
 
 import google.genai as genai
 from dotenv import load_dotenv
@@ -13,6 +15,10 @@ load_dotenv()
 
 MODEL_NAME = "gemini-2.5-flash"
 _client: genai.Client | None = None
+
+_RETRYABLE_API_ERRORS = ("429", "503", "RESOURCE_EXHAUSTED", "UNAVAILABLE")
+_CODE_BLOCK_RE = re.compile(r"^```[\w]*\n?", re.MULTILINE)
+_CODE_BLOCK_END_RE = re.compile(r"\n?```\s*$", re.MULTILINE)
 
 
 def _get_client() -> genai.Client:
@@ -26,10 +32,24 @@ def _get_client() -> genai.Client:
     return _client
 
 
+def _strip_markdown_fences(text: str) -> str:
+    """마크다운 코드블록 울타리(```json ... ```)를 제거."""
+    text = _CODE_BLOCK_RE.sub("", text)
+    text = _CODE_BLOCK_END_RE.sub("", text)
+    return text.strip()
+
+
+def _try_repair_json(raw: str) -> str:
+    """흔한 LLM JSON 오류를 보정 시도."""
+    # trailing comma 제거: ,\s*} 또는 ,\s*]
+    repaired = re.sub(r",\s*([}\]])", r"\1", raw)
+    return repaired
+
+
 def call_gemini_batch(prompt: str) -> list[dict]:
     """Gemini API를 호출하고 JSON 배열 응답을 파싱해 반환.
 
-    429/503 에러 시 최대 3회 지수 백오프 재시도.
+    API 에러(429/503) 및 JSON 파싱 에러 시 최대 3회 재시도.
 
     Args:
         prompt: 배치 퀴즈 생성 프롬프트.
@@ -39,10 +59,8 @@ def call_gemini_batch(prompt: str) -> list[dict]:
 
     Raises:
         RuntimeError: API 키 없음 또는 API 호출 실패.
-        ValueError: JSON 파싱 실패.
+        ValueError: 최대 재시도 후에도 JSON 파싱 실패.
     """
-    import time
-
     client = _get_client()
     gen_config = types.GenerateContentConfig(
         system_instruction=SYSTEM_INSTRUCTION,
@@ -53,42 +71,59 @@ def call_gemini_batch(prompt: str) -> list[dict]:
     )
 
     max_retries = 3
-    last_error = None
+    last_error: Exception | None = None
+
     for attempt in range(max_retries + 1):
+        # ── 1) API 호출 ──
         try:
             response = client.models.generate_content(
                 model=MODEL_NAME,
                 contents=prompt,
                 config=gen_config,
             )
-            break
         except Exception as e:
             last_error = e
             err_str = str(e)
-            if attempt < max_retries and ("429" in err_str or "503" in err_str or "RESOURCE_EXHAUSTED" in err_str or "UNAVAILABLE" in err_str):
+            if attempt < max_retries and any(k in err_str for k in _RETRYABLE_API_ERRORS):
                 wait_sec = 15.0 * (2 ** attempt)
                 print(f"[Quiz Gen] Gemini API 재시도 ({attempt+1}/{max_retries}) — {wait_sec:.0f}초 대기")
                 time.sleep(wait_sec)
-            else:
-                raise RuntimeError(f"Gemini API 호출 실패: {e}") from e
-    else:
-        raise RuntimeError(f"Gemini API {max_retries}회 재시도 후에도 실패: {last_error}")
+                continue
+            raise RuntimeError(f"Gemini API 호출 실패: {e}") from e
 
-    raw_text = response.text.strip()
+        # ── 2) 응답 텍스트 정리 ──
+        raw_text = response.text.strip()
+        raw_text = _strip_markdown_fences(raw_text)
 
-    # 마크다운 코드블록 제거
-    if raw_text.startswith("```"):
-        lines = raw_text.splitlines()
-        raw_text = "\n".join(
-            line for line in lines if not line.startswith("```")
-        ).strip()
+        # ── 3) JSON 파싱 (실패 시 보정 후 1회 더 시도) ──
+        try:
+            parsed = json.loads(raw_text)
+        except json.JSONDecodeError:
+            try:
+                parsed = json.loads(_try_repair_json(raw_text))
+                print(f"[Quiz Gen] JSON 자동 보정 성공 (attempt {attempt+1})")
+            except json.JSONDecodeError as e2:
+                last_error = e2
+                if attempt < max_retries:
+                    wait_sec = 10.0 * (2 ** attempt)
+                    print(
+                        f"[Quiz Gen] JSON 파싱 실패, 재시도 ({attempt+1}/{max_retries}) — {wait_sec:.0f}초 대기\n"
+                        f"  에러: {e2}\n  원문(앞 500자): {raw_text[:500]}"
+                    )
+                    time.sleep(wait_sec)
+                    continue
+                raise ValueError(
+                    f"JSON 파싱 실패 ({max_retries+1}회 시도): {e2}\n원문(앞 500자): {raw_text[:500]}"
+                ) from e2
 
-    try:
-        parsed = json.loads(raw_text)
-    except json.JSONDecodeError as e:
-        raise ValueError(f"JSON 파싱 실패: {e}\n원문(앞 300자): {raw_text[:300]}") from e
+        if not isinstance(parsed, list):
+            last_error = ValueError(f"응답이 배열이 아닙니다. 타입: {type(parsed)}")
+            if attempt < max_retries:
+                print(f"[Quiz Gen] 응답이 배열이 아님, 재시도 ({attempt+1}/{max_retries})")
+                time.sleep(10.0)
+                continue
+            raise last_error
 
-    if not isinstance(parsed, list):
-        raise ValueError(f"응답이 배열이 아닙니다. 타입: {type(parsed)}")
+        return parsed
 
-    return parsed
+    raise RuntimeError(f"Gemini 퀴즈 생성 {max_retries+1}회 시도 후 실패: {last_error}")


### PR DESCRIPTION
## Summary
- Gemini LLM이 잘못된 JSON 반환 시 바로 에러 대신 **최대 3회 재시도**
- trailing comma 등 흔한 LLM JSON 오류 **자동 보정** 후 파싱 재시도
- 마크다운 코드블록 제거 로직을 정규식으로 강화
- 에러 로그 원문 출력 300자 → 500자로 확대

## 배경
퀴즈 생성 단계에서 `JSON 파싱 실패: Expecting property name enclosed in double quotes` 에러가 간헐적으로 발생. 기존에는 API 에러(429/503)만 재시도하고 JSON 파싱 에러는 바로 실패 처리됨.

## Test plan
- [ ] 퀴즈 생성 파이프라인 실행 후 JSON 파싱 에러 없이 완료 확인
- [ ] 의도적으로 잘못된 JSON 응답 시 재시도 로그 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)