### PR TITLE
fix: 재시도/트리거 시 409 응답에서 에러 대신 폴링 유지

### DIFF
--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -599,7 +599,12 @@ export function LecturesPage() {
       setProcessingLectures((prev) => new Set(prev).add(id))
       try {
         await triggerLectureProcess(id, false)
-      } catch {
+      } catch (err: unknown) {
+        const status = (err as { status?: number }).status
+        if (status === 409) {
+          // 이미 처리 중/대기 중 → 폴링이 이어받으므로 spinner 유지
+          continue
+        }
         failed.push(id)
         setProcessingLectures((prev) => {
           const next = new Set(prev)
@@ -622,7 +627,12 @@ export function LecturesPage() {
     setProcessingLectures((prev) => new Set(prev).add(lectureId))
     try {
       await triggerLectureProcess(lectureId)
-    } catch {
+    } catch (err: unknown) {
+      const status = (err as { status?: number }).status
+      if (status === 409) {
+        // 이미 처리 중/대기 중 → 폴링이 이어받으므로 spinner 유지
+        return
+      }
       setProcessingLectures((prev) => {
         const next = new Set(prev)
         next.delete(lectureId)


### PR DESCRIPTION
## Summary
- `handleRetry`, `handleStartSelected`에서 409(이미 처리 중) 응답 시 에러 표시 대신 spinner 유지
- 기존 `handleResume`에만 있던 409 처리 로직을 나머지 핸들러에도 동일 적용
- 중복 트리거 시 사용자에게 에러가 아닌 정상 폴링 UI를 표시

## 배경
서버 재시작 후 에러 상태 강의를 "다시 시도"하면 첫 트리거는 성공하지만, 중복 트리거가 409를 받아 에러로 표시되는 문제.

## Test plan
- [ ] 에러 상태 강의에서 "다시 시도" 클릭 → 처리 중 UI 유지 확인
- [ ] 여러 강의 동시 선택 후 분석 시작 → 409 시 에러 아닌 대기 UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)