### PR TITLE
fix: 폴링 네트워크 복원력 강화 + 퀴즈 진행 UI

### DIFF
--- a/frontend/src/components/ProcessingStatus.tsx
+++ b/frontend/src/components/ProcessingStatus.tsx
@@ -203,6 +203,31 @@ export function ProcessingStatus({
   )
 }
 
+// ── 퀴즈 생성 detail 파싱 ──
+
+interface QuizProgress {
+  generated?: number
+  total?: number
+  qaProgress?: string
+  raw: string
+}
+
+function parseQuizDetail(detail: string): QuizProgress {
+  const result: QuizProgress = { raw: detail }
+  // "12/30개 생성 완료" 또는 "12/30" 패턴
+  const genMatch = detail.match(/(\d+)\s*\/\s*(\d+)\s*개?\s*(생성|완료)?/)
+  if (genMatch) {
+    result.generated = parseInt(genMatch[1], 10)
+    result.total = parseInt(genMatch[2], 10)
+  }
+  // "QA 3/12" 또는 "QA 진행 3/12" 패턴
+  const qaMatch = detail.match(/QA\s*(?:진행\s*)?(\d+\s*\/\s*\d+)/)
+  if (qaMatch) {
+    result.qaProgress = qaMatch[1]
+  }
+  return result
+}
+
 // ── 개별 단계 행 ──
 
 interface StepRowProps {
@@ -212,6 +237,8 @@ interface StepRowProps {
 
 function StepRow({ step, index }: StepRowProps) {
   const { name, status, detail, subSteps } = step
+  const isQuizStep = name === '퀴즈 생성'
+  const quizProgress = isQuizStep && detail ? parseQuizDetail(detail) : null
 
   return (
     <div className={`tml-processing-step tml-processing-step--${status} ${subSteps && subSteps.length > 0 && status !== 'pending' ? 'tml-processing-step--expanded' : ''}`}>
@@ -224,12 +251,28 @@ function StepRow({ step, index }: StepRowProps) {
       <div className="tml-processing-step__content">
         <div className="tml-processing-step__name-row">
           <span className="tml-processing-step__name">{name}</span>
-          {detail && status !== 'pending' && (
+          {detail && status !== 'pending' && !quizProgress?.generated && (
             <span className="tml-processing-step__detail">{detail}</span>
           )}
         </div>
 
-        {status === 'running' && subSteps === undefined && (
+        {/* 퀴즈 생성 세부 진행 표시 */}
+        {quizProgress && status === 'running' && quizProgress.generated != null && (
+          <div className="tml-processing-quiz-progress">
+            <div className="tml-processing-quiz-progress__bar-track">
+              <div
+                className="tml-processing-quiz-progress__bar-fill"
+                style={{ width: `${quizProgress.total ? (quizProgress.generated / quizProgress.total) * 100 : 0}%` }}
+              />
+            </div>
+            <div className="tml-processing-quiz-progress__labels">
+              <span>문제 생성 {quizProgress.generated}/{quizProgress.total ?? '?'}개</span>
+              {quizProgress.qaProgress && <span>QA {quizProgress.qaProgress}</span>}
+            </div>
+          </div>
+        )}
+
+        {status === 'running' && subSteps === undefined && !(quizProgress?.generated != null) && (
           <div className="tml-processing-step__track">
             <div className="tml-processing-step__fill tml-processing-fill--running" />
           </div>

--- a/frontend/src/hooks/useProcessingStatus.ts
+++ b/frontend/src/hooks/useProcessingStatus.ts
@@ -51,11 +51,16 @@ export function useProcessingStatus({
 
     let stopped = false
     let timer: ReturnType<typeof setTimeout>
-    let retryCount = 0
+    let networkRetryCount = 0     // DNS/네트워크 에러 전용 카운터
+    let apiRetryCount = 0         // API 응답 에러 전용 카운터
     let emptyStepsCount = 0
     let lastLogTime = 0
+    let lastPhase4Detail = ''     // TASK-002: 로그 중복 방지용
+    let lastQuizDetail = ''       // TASK-002: 로그 중복 방지용
     const LOG_INTERVAL = 60000 // 콘솔 로그는 60초마다
-    const MAX_RETRIES = 5
+    const MAX_NETWORK_RETRIES = 20  // 네트워크 에러는 넉넉하게
+    const MAX_API_RETRIES = 5       // API 에러는 기존대로
+    const BACKOFF_CAP_MS = 30000    // 백오프 상한 30초
     const MAX_EMPTY_STEPS = 10
     const MAX_POLL_MS = 60 * 60 * 1000 // 60분 타임아웃
     const pollStartTime = Date.now()
@@ -77,7 +82,7 @@ export function useProcessingStatus({
       const shouldLog = now - lastLogTime >= LOG_INTERVAL
       if (shouldLog) {
         lastLogTime = now
-        console.log(`[폴링] ${target} — 상태 조회 중... (재시도: ${retryCount})`)
+        console.log(`[폴링] ${target} — 상태 조회 중... (네트워크 재시도: ${networkRetryCount}, API 재시도: ${apiRetryCount})`)
       }
       try {
         const result = lectureId
@@ -85,7 +90,8 @@ export function useProcessingStatus({
           : await fetchWeekStatus(week!)
         if (stopped) return
 
-        retryCount = 0
+        networkRetryCount = 0
+        apiRetryCount = 0
         setStatus(result)
 
         const steps = result.steps ?? []
@@ -100,13 +106,15 @@ export function useProcessingStatus({
           console.log(`[폴링] ${target} — 응답: ${result.status}${percentLabel}`, steps, result.error_message ?? '')
         }
 
-        // 세부 진행 상황이 있는 step은 매 폴링마다 즉시 출력 (throttle 없음)
+        // TASK-002: detail 값이 변경될 때만 출력 (중복 방지)
         const phase4Step = steps.find((s) => s.name === 'Step 4: 명제 추출')
-        if (phase4Step?.status === 'running' && phase4Step?.detail) {
+        if (phase4Step?.status === 'running' && phase4Step?.detail && phase4Step.detail !== lastPhase4Detail) {
+          lastPhase4Detail = phase4Step.detail
           console.log(`[폴링] ${target} — [명제 추출] ${phase4Step.detail}`)
         }
         const quizStep = steps.find((s) => s.name === '퀴즈 생성')
-        if (quizStep?.status === 'running' && quizStep?.detail) {
+        if (quizStep?.status === 'running' && quizStep?.detail && quizStep.detail !== lastQuizDetail) {
+          lastQuizDetail = quizStep.detail
           console.log(`[폴링] ${target} — [퀴즈 생성] ${quizStep.detail}`)
         }
 
@@ -148,16 +156,35 @@ export function useProcessingStatus({
         timer = setTimeout(poll, interval)
       } catch (err) {
         if (stopped) return
-        retryCount++
-        console.error(`[폴링] ${target} — 네트워크/요청 실패 (${retryCount}/${MAX_RETRIES}):`, err)
-        if (retryCount >= MAX_RETRIES) {
-          const msg = '서버와 연결할 수 없습니다. 네트워크를 확인해주세요.'
-          console.error(`[폴링] ${target} — 최대 재시도 초과, 에러로 전환`)
-          setError(msg)
-          onErrorRef.current?.(msg)
-          return
+
+        // TASK-001: 네트워크 에러와 API 에러의 재시도 카운터 분리
+        const isNetworkError = err instanceof TypeError
+          || (err instanceof Error && /network|fetch|abort|dns|ENOTFOUND|ERR_NAME_NOT_RESOLVED/i.test(err.message))
+        if (isNetworkError) {
+          networkRetryCount++
+          const delay = Math.min(interval * Math.pow(2, networkRetryCount), BACKOFF_CAP_MS)
+          console.error(`[폴링] ${target} — 네트워크 에러 (${networkRetryCount}/${MAX_NETWORK_RETRIES}):`, err)
+          if (networkRetryCount >= MAX_NETWORK_RETRIES) {
+            const msg = '서버와 연결할 수 없습니다. 네트워크를 확인해주세요.'
+            console.error(`[폴링] ${target} — 네트워크 재시도 초과, 에러로 전환`)
+            setError(msg)
+            onErrorRef.current?.(msg)
+            return
+          }
+          timer = setTimeout(poll, delay)
+        } else {
+          apiRetryCount++
+          const delay = Math.min(interval * Math.pow(2, apiRetryCount), BACKOFF_CAP_MS)
+          console.error(`[폴링] ${target} — API 요청 실패 (${apiRetryCount}/${MAX_API_RETRIES}):`, err)
+          if (apiRetryCount >= MAX_API_RETRIES) {
+            const msg = '서버와 연결할 수 없습니다. 잠시 후 다시 시도해주세요.'
+            console.error(`[폴링] ${target} — API 재시도 초과, 에러로 전환`)
+            setError(msg)
+            onErrorRef.current?.(msg)
+            return
+          }
+          timer = setTimeout(poll, delay)
         }
-        timer = setTimeout(poll, interval * Math.pow(2, retryCount))
       }
     }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3417,6 +3417,36 @@ body::after {
   font-weight: 400;
 }
 
+/* 퀴즈 생성 세부 진행 바 */
+.tml-processing-quiz-progress {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.tml-processing-quiz-progress__bar-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--tml-surface-alt, #e5e7eb);
+  overflow: hidden;
+}
+
+.tml-processing-quiz-progress__bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--tml-accent, #6366f1);
+  transition: width 0.4s ease;
+}
+
+.tml-processing-quiz-progress__labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: var(--tml-ink-muted);
+  font-weight: 500;
+}
+
 /* R-1: 극소형 모바일(375px) padding 과대 방지 */
 @media (max-width: 479px) {
   .tml-page-container {


### PR DESCRIPTION
## Summary
- 네트워크/API 에러 재시도 카운터 분리 (네트워크 20회 vs API 5회) + 백오프 상한 30초
- 명제 추출·퀴즈 생성 로그 detail이 변경될 때만 출력 (중복 제거)
- 퀴즈 생성 단계에 세부 프로그레스 바 + 문제 생성 개수/QA 진행 표시 UI 추가

## 관련 태스크
- TASK-001: 폴링 네트워크 에러 복원력 강화
- TASK-002: 폴링 로그 중복 제거 + 퀴즈 생성 세부 진행 표시

## Test plan
- [ ] DNS 일시 장애 시 20회까지 재시도 후 복구 확인
- [ ] 콘솔에서 동일 detail 반복 출력 안 되는지 확인
- [ ] 퀴즈 생성 중 프로그레스 바 + 개수 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)