### PR TITLE
fix: 퀴즈 생성 max_output_tokens 65536으로 증가

### DIFF
--- a/pipeline/quiz_generation/quiz_generator.py
+++ b/pipeline/quiz_generation/quiz_generator.py
@@ -67,7 +67,7 @@ def call_gemini_batch(prompt: str) -> list[dict]:
         temperature=0.7,
         top_p=0.95,
         response_mime_type="application/json",
-        max_output_tokens=8192,
+        max_output_tokens=65536,
     )
 
     max_retries = 3


### PR DESCRIPTION
## Summary
- `pipeline/quiz_generation/quiz_generator.py`의 `max_output_tokens`를 8192 → 65536으로 증가
- 30개 MCQ 한국어 퀴즈(4지선다 + explanation + source_text) 생성 시 JSON 잘림 방지

## 관련 태스크
- TASK-003: 퀴즈 생성 max_output_tokens 증가

## Test plan
- [ ] 30개 퀴즈 생성 시 `Unterminated string` 파싱 에러 발생하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)