### PR TITLE
feat: 카탈로그 job 상태 오버레이 + Phase 4 중간저장/재개

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -42,6 +42,8 @@ from app.state import (
     clear_week_job,
     start_lecture_job_if_idle,
     start_week_job_if_idle,
+    lecture_jobs as _lecture_jobs,
+    week_jobs as _week_jobs,
 )
 
 router = APIRouter(prefix="/api", tags=["산출물"])
@@ -91,10 +93,51 @@ def _validate_week(week: int) -> int:
 # --- 강의 카탈로그 ---
 
 
+_JOB_OVERRIDE_STATUSES = frozenset({
+    ProcessingStatus.processing,
+    ProcessingStatus.queued,
+    ProcessingStatus.error,
+})
+
+
+def _overlay_lecture_jobs(lectures: list[LectureCatalog]) -> list[LectureCatalog]:
+    """카탈로그(파일 기반)에 인메모리 job 상태를 덮어씌운다.
+    processing/queued/error 상태의 job이 있으면 해당 상태로 교체."""
+    if not _lecture_jobs:
+        return lectures
+    result = []
+    for lec in lectures:
+        job = _lecture_jobs.get(lec.lecture_id)
+        if job and job.status in _JOB_OVERRIDE_STATUSES:
+            lec = lec.model_copy(update={"status": job.status})
+        result.append(lec)
+    return result
+
+
+def _overlay_week_summaries(weeks: list[WeekSummary]) -> list[WeekSummary]:
+    """주차 요약의 강의 리스트에 인메모리 job 상태를 반영한다."""
+    if not _lecture_jobs:
+        return weeks
+    result = []
+    for w in weeks:
+        updated_lectures = _overlay_lecture_jobs(w.lectures)
+        if updated_lectures is not w.lectures:
+            completed_count = sum(
+                1 for l in updated_lectures if l.status == ProcessingStatus.completed
+            )
+            w = w.model_copy(update={
+                "lectures": updated_lectures,
+                "completed_count": completed_count,
+            })
+        result.append(w)
+    return result
+
+
 @router.get("/lectures", response_model=list[LectureCatalog])
 async def get_lectures():
     """전체 강의 목록 (data/raw/ 스캔)."""
-    return await asyncio.to_thread(load_lectures)
+    lectures = await asyncio.to_thread(load_lectures)
+    return _overlay_lecture_jobs(lectures)
 
 
 @router.get("/lectures/{lecture_id}", response_model=LectureCatalog)
@@ -102,7 +145,7 @@ async def get_lecture(lecture_id: str):
     """단일 강의 상세. 없으면 404."""
     _validate_lecture_id(lecture_id)
     lectures = await asyncio.to_thread(load_lectures)
-    for lec in lectures:
+    for lec in _overlay_lecture_jobs(lectures):
         if lec.lecture_id == lecture_id:
             return lec
     raise HTTPException(status_code=404, detail=f"강의 {lecture_id}를 찾을 수 없습니다.")
@@ -111,7 +154,8 @@ async def get_lecture(lecture_id: str):
 @router.get("/weeks", response_model=list[WeekSummary])
 async def get_weeks():
     """존재하는 주차 목록 (빈 주차 제외)."""
-    return await asyncio.to_thread(load_weeks)
+    weeks = await asyncio.to_thread(load_weeks)
+    return _overlay_week_summaries(weeks)
 
 
 @router.get("/weeks/{week}", response_model=WeekSummary)
@@ -119,7 +163,7 @@ async def get_week(week: int):
     """특정 주차 상세. 없으면 404."""
     _validate_week(week)
     weeks = await asyncio.to_thread(load_weeks)
-    for w in weeks:
+    for w in _overlay_week_summaries(weeks):
         if w.week == week:
             return w
     raise HTTPException(status_code=404, detail=f"{week}주차 데이터를 찾을 수 없습니다.")

--- a/frontend/src/pages/LecturesPage.tsx
+++ b/frontend/src/pages/LecturesPage.tsx
@@ -550,16 +550,25 @@ export function LecturesPage() {
     const serverActiveIds = new Set(
       allLectures.filter((l) => l.status === 'processing' || l.status === 'partial').map((l) => l.lecture_id),
     )
-    const serverCompletedIds = new Set(
-      allLectures.filter((l) => l.status === 'completed').map((l) => l.lecture_id),
+    const serverInactiveIds = new Set(
+      allLectures.filter((l) => l.status === 'completed' || l.status === 'error').map((l) => l.lecture_id),
     )
 
     setProcessingLectures((prev) => {
       const next = new Set(prev)
       serverActiveIds.forEach((id) => next.add(id))
-      serverCompletedIds.forEach((id) => next.delete(id))
+      serverInactiveIds.forEach((id) => next.delete(id))
       return next
     })
+    // 서버에서 error로 내려온 강의는 erroredLectures에도 반영
+    const serverErrorIds = allLectures.filter((l) => l.status === 'error').map((l) => l.lecture_id)
+    if (serverErrorIds.length > 0) {
+      setErroredLectures((prev) => {
+        const next = new Set(prev)
+        serverErrorIds.forEach((id) => next.add(id))
+        return next
+      })
+    }
   }, [weeks])
 
   const activeWeek = searchParams.get('week') ? Number(searchParams.get('week')) : null

--- a/pipeline/preprocessor/04_extractor.py
+++ b/pipeline/preprocessor/04_extractor.py
@@ -176,51 +176,104 @@ class FactExtractor:
                         continue
 
         stats = {"input_chunks": len(chunks), "output_props": 0}
-        results = []
-        prop_counter = 1
         total_chunks = len(chunks)
+        output_dir.mkdir(parents=True, exist_ok=True)
 
-        for i, chunk in enumerate(tqdm(chunks, desc=f"  [지식 추출] {filepath.name}", leave=False)):
-            text = chunk.get("text", "")
-            keywords = chunk.get("keywords", [])
+        partial_path = output_dir / f"{day}.jsonl.partial"
+        out_path = output_dir / f"{day}.jsonl"
 
-            props = self.extract_pattern(text)
+        # — 재개 로직: .partial 파일이 있으면 이어서 진행 —
+        resume_from = 0
+        existing_prop_count = 0
+        if partial_path.exists():
+            valid_lines = []
+            for raw_line in partial_path.read_text(encoding="utf-8").splitlines():
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    valid_lines.append(json.loads(raw_line))
+                except json.JSONDecodeError:
+                    break  # 마지막 불완전 라인 — 여기서 끊고 이후 덮어씀
+            resume_from = len(valid_lines)
+            existing_prop_count = sum(len(entry.get("props", [])) for entry in valid_lines)
+            if resume_from > 0:
+                # 불완전 라인 제거: 유효한 부분만 다시 쓰기
+                with open(partial_path, "w", encoding="utf-8") as f:
+                    for entry in valid_lines:
+                        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                print(f"[Phase 4] 중간저장 발견 — {resume_from}/{total_chunks} 청크 완료, {existing_prop_count}개 명제 재개")
 
-            if len(text) > 30 and (self.use_gemini or self.use_ollama):
-                llm_props = self.extract_llm(text, keywords)
-                for lp in llm_props:
-                    lp["method"] = "llm"
-                props.extend(llm_props)
+        # — 청크별 처리 + 즉시 저장 —
+        current_prop_count = existing_prop_count
+        open_mode = "a" if resume_from > 0 else "w"
+        with open(partial_path, open_mode, encoding="utf-8") as pf:
+            for i, chunk in enumerate(tqdm(chunks, desc=f"  [지식 추출] {filepath.name}", leave=False)):
+                if i < resume_from:
+                    # 이미 처리된 청크는 진행률만 갱신하고 스킵
+                    if progress_callback:
+                        progress_callback(i + 1, total_chunks, existing_prop_count)
+                    continue
 
-            for prop in props:
-                c_candidates = list(set([prop.get("concept", "")] + keywords))
-                while "" in c_candidates: c_candidates.remove("")
+                text = chunk.get("text", "")
+                keywords = chunk.get("keywords", [])
 
-                results.append({
-                    "prop_id": f"{day}_P{prop_counter:04d}",
+                props = self.extract_pattern(text)
+
+                if len(text) > 30 and (self.use_gemini or self.use_ollama):
+                    llm_props = self.extract_llm(text, keywords)
+                    for lp in llm_props:
+                        lp["method"] = "llm"
+                    props.extend(llm_props)
+
+                # 청크 단위로 partial 파일에 즉시 기록
+                chunk_entry = {
+                    "chunk_index": i,
                     "chunk_id": chunk.get("chunk_id", ""),
-                    "type": prop.get("type", "fact"),
-                    "text": prop.get("fact", ""),
-                    "concept_candidates": c_candidates,
-                    "processing_type": chunk.get("processing_type", "base"),
-                    "meta": {
-                        "source_sents": chunk.get("sent_ids", []),
-                        "model": "gemini-2.5-flash" if self.use_gemini else ("ollama" if self.use_ollama else "pattern")
-                    }
-                })
+                    "props": [],
+                }
+                for prop in props:
+                    c_candidates = list(set([prop.get("concept", "")] + keywords))
+                    while "" in c_candidates:
+                        c_candidates.remove("")
+                    chunk_entry["props"].append({
+                        "type": prop.get("type", "fact"),
+                        "text": prop.get("fact", ""),
+                        "concept_candidates": c_candidates,
+                        "processing_type": chunk.get("processing_type", "base"),
+                        "meta": {
+                            "source_sents": chunk.get("sent_ids", []),
+                            "model": "gemini-2.5-flash" if self.use_gemini else ("ollama" if self.use_ollama else "pattern"),
+                        },
+                    })
+
+                pf.write(json.dumps(chunk_entry, ensure_ascii=False) + "\n")
+                pf.flush()
+
+                current_prop_count += len(chunk_entry["props"])
+                if progress_callback:
+                    progress_callback(i + 1, total_chunks, current_prop_count)
+
+        # — 완료: partial → 최종 jsonl 변환 —
+        all_props = []
+        prop_counter = 1
+        for raw_line in partial_path.read_text(encoding="utf-8").splitlines():
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+            entry = json.loads(raw_line)
+            for prop in entry.get("props", []):
+                prop["prop_id"] = f"{day}_P{prop_counter:04d}"
+                prop["chunk_id"] = entry.get("chunk_id", "")
+                all_props.append(prop)
                 prop_counter += 1
 
-            if progress_callback:
-                progress_callback(i + 1, total_chunks, len(results))
-
-        stats["output_props"] = len(results)
-        
-        output_dir.mkdir(parents=True, exist_ok=True)
-        out_path = output_dir / f"{day}.jsonl"
         with open(out_path, "w", encoding="utf-8") as f:
-            for item in results:
+            for item in all_props:
                 f.write(json.dumps(item, ensure_ascii=False) + "\n")
-                
+
+        partial_path.unlink()
+        stats["output_props"] = len(all_props)
         return stats
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- 카탈로그 API(`/lectures`, `/weeks`)에 인메모리 job 상태(processing/queued/error)를 오버레이하여 실시간 상태 반영
- 프론트엔드에서 서버 error 상태 강의를 erroredLectures에 동기화
- Phase 4 FactExtractor에 청크 단위 중간저장(`.partial`) + 재개 기능 추가 (TASK-005)

## Test plan
- [ ] `/api/lectures` 응답에서 processing 중인 강의 상태가 정확히 반영되는지 확인
- [ ] 강의 분석 중 에러 발생 시 프론트엔드에 에러 상태 표시 확인
- [ ] Phase 4 실행 중 중단 후 재시작 시 `.partial` 파일에서 이어서 처리되는지 확인
- [ ] EC2 배포 후 정상 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)